### PR TITLE
Py formatting

### DIFF
--- a/Tools/Accessory_Tools.pyt
+++ b/Tools/Accessory_Tools.pyt
@@ -5,19 +5,19 @@
 #### Python version: 3+
 #### ArcGIS Pro: 2.6.4 and above
 
+from datetime import datetime
+
 import arcpy
-from arcpy import env
-from arcpy.sa import *
 import numpy as np
 import pandas as pd
-import collections
-from scipy.spatial.distance import cdist
+from arcpy import env
+from arcpy.sa import *
 from pandas.core.common import flatten
-from datetime import datetime
-import sys
+
 arcpy.CheckOutExtension("Spatial")
 
-class Toolbox(object):
+
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -27,11 +27,16 @@ class Toolbox(object):
         # List of tool classes associated with this toolbox
         # There are two tools. Merge Connected Features Tool merges polygon features that are connected through shared points or borders.
         # Connect Nearby Linear Features Tool connects nearby linear bathymetric low features.
-        self.tools = [Update_Features_Tool,Merge_Connected_Features_Tool,Connect_Nearby_Linear_Features_Tool,Connect_Nearby_Linear_HF_Features_Tool]
+        self.tools = [
+            Update_Features_Tool,
+            Merge_Connected_Features_Tool,
+            Connect_Nearby_Linear_Features_Tool,
+            Connect_Nearby_Linear_HF_Features_Tool,
+        ]
 
 
 # This tool merges overlapped features and update the feature boundary
-class Update_Features_Tool(object):
+class Update_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Update Feature Boundary Tool"
@@ -48,15 +53,17 @@ class Update_Features_Tool(object):
             datatype="GPFeatureLayer",
             parameterType="Required",
             direction="Input",
-            multiValue=True)
+            multiValue=True,
+        )
         # fourth parameter
         param1 = arcpy.Parameter(
             displayName="Output Features After Updating the Feature Boundaries",
             name="dissolvedFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")        
-        
+            direction="Output",
+        )
+
         parameters = [param0, param1]
         return parameters
 
@@ -68,7 +75,6 @@ class Update_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -79,13 +85,13 @@ class Update_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         in_feature_set = parameters[0].valueAsText
-        dissolvedFeat = parameters[1].valueAsText           
-        inFeats = in_feature_set.split(";")            
+        dissolvedFeat = parameters[1].valueAsText
+        inFeats = in_feature_set.split(";")
         # enable the helper functions
         helper = helpers()
-        
+
         dissolvedFeat = helper.convert_backslach_forwardslach(dissolvedFeat)
         inputs = []
         # loop through the input datasets and get their full path
@@ -94,48 +100,57 @@ class Update_Features_Tool(object):
             # In this case, the full path needs to be obtained from the map layer
             if inFeat.rfind("/") < 0:
                 aprx = arcpy.mp.ArcGISProject("CURRENT")
-                m = aprx.activeMap            
+                m = aprx.activeMap
                 for lyr in m.listLayers():
                     if lyr.isFeatureLayer:
                         if inFeat == lyr.name:
-                            inFeat = helper.convert_backslach_forwardslach(lyr.dataSource)                            
-        
-                           # check that the input feature class is in a correct format
+                            inFeat = helper.convert_backslach_forwardslach(
+                                lyr.dataSource
+                            )
+
+                            # check that the input feature class is in a correct format
                             vecDesc = arcpy.Describe(inFeat)
-                            vecType = vecDesc.dataType        
-                            if (vecType != 'FeatureClass') or (inFeat.rfind(".gdb") == -1):
-                                messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+                            vecType = vecDesc.dataType
+                            if (vecType != "FeatureClass") or (
+                                inFeat.rfind(".gdb") == -1
+                            ):
+                                messages.addErrorMessage(
+                                    "The input featureclass must be a feature class in a File GeoDatabase!"
+                                )
                                 raise arcpy.ExecuteError
                             else:
                                 inputs.append(inFeat)
 
-        
         # check that the output featureclass is in a correct format
         if dissolvedFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # merge the input datasets
-        mergedFeat = 'mergedFeat'
-        arcpy.management.Merge(inputs,mergedFeat)
+        mergedFeat = "mergedFeat"
+        arcpy.management.Merge(inputs, mergedFeat)
         arcpy.AddMessage("merge done")
         # add a temporary field
-        fieldName = 'temp'
-        fieldType = 'LONG'
+        fieldName = "temp"
+        fieldType = "LONG"
         fields = arcpy.ListFields(mergedFeat)
         field_names = [f.name for f in fields]
         # check the 'temp' field exists
         # if not, add it
-        if fieldName not in field_names:            
-            arcpy.management.AddField(mergedFeat,fieldName,fieldType)
+        if fieldName not in field_names:
+            arcpy.management.AddField(mergedFeat, fieldName, fieldType)
 
         expression = "1"
-        arcpy.management.CalculateField(mergedFeat,fieldName,expression)
+        arcpy.management.CalculateField(mergedFeat, fieldName, expression)
         # dissolve to obtain updated boundaries
-        arcpy.management.Dissolve(mergedFeat,dissolvedFeat,fieldName,"","SINGLE_PART")
+        arcpy.management.Dissolve(
+            mergedFeat, dissolvedFeat, fieldName, "", "SINGLE_PART"
+        )
         arcpy.AddMessage("dissolve done")
         # delete temporary field and dataset
-        arcpy.management.DeleteField(dissolvedFeat,fieldName)
+        arcpy.management.DeleteField(dissolvedFeat, fieldName)
 
         arcpy.management.Delete(mergedFeat)
 
@@ -143,11 +158,13 @@ class Update_Features_Tool(object):
 
 
 # This tool merges polygon features that are connected through shared points or borders.
-class Merge_Connected_Features_Tool(object):
+class Merge_Connected_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Merge Connected Features Tool"
-        self.description = "Merge/dissolve polygon features that are connected by shared points"
+        self.description = (
+            "Merge/dissolve polygon features that are connected by shared points"
+        )
         self.canRunInBackground = False
 
     def getParameterInfo(self):
@@ -159,15 +176,17 @@ class Merge_Connected_Features_Tool(object):
             name="inFeat",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         # fourth parameter
         param1 = arcpy.Parameter(
             displayName="Output Features After Merging Features Connected by Shared Points",
             name="dissolveFeat2",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")        
-        
+            direction="Output",
+        )
+
         parameters = [param0, param1]
         return parameters
 
@@ -179,7 +198,6 @@ class Merge_Connected_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -190,10 +208,10 @@ class Merge_Connected_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeat = parameters[0].valueAsText
-        dissolveFeat2 = parameters[1].valueAsText           
-        
+        dissolveFeat2 = parameters[1].valueAsText
+
         # enable the helper functions
         helper = helpers()
         inFeat = helper.convert_backslach_forwardslach(inFeat)
@@ -203,115 +221,153 @@ class Merge_Connected_Features_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeat.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeat == lyr.name:
                         inFeat = helper.convert_backslach_forwardslach(lyr.dataSource)
-        
-       # check that the input feature class is in a correct format
-        vecDesc = arcpy.Describe(inFeat)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeat.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
-            raise arcpy.ExecuteError
 
+        # check that the input feature class is in a correct format
+        vecDesc = arcpy.Describe(inFeat)
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeat.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
+            raise arcpy.ExecuteError
 
         # check that the output featureclass is in a correct format
         if dissolveFeat2.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass after merging only features connected by shared point must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass after merging only features connected by shared point must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = inFeat[0:inFeat.rfind("/")] 
-        env.workspace=workspaceName
+
+        workspaceName = inFeat[0 : inFeat.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
-
-        helper.addIDField(inFeat,'featID')
+        helper.addIDField(inFeat, "featID")
 
         # Generate near table between individual input poygon features
         itemList = []
-        outTable = 'nearTable'
+        outTable = "nearTable"
         itemList.append(outTable)
-        location = 'NO_LOCATION'
-        angle = 'NO_ANGLE'
-        closest = 'ALL'
-        searchRadius = '100 Meters'
-        arcpy.GenerateNearTable_analysis(inFeat,inFeat,outTable,search_radius=searchRadius,location=location,angle=angle,closest=closest)
+        location = "NO_LOCATION"
+        angle = "NO_ANGLE"
+        closest = "ALL"
+        searchRadius = "100 Meters"
+        arcpy.GenerateNearTable_analysis(
+            inFeat,
+            inFeat,
+            outTable,
+            search_radius=searchRadius,
+            location=location,
+            angle=angle,
+            closest=closest,
+        )
 
         cursor = arcpy.SearchCursor(outTable)
         inIDList = []
         nearIDList = []
-        
+
         # obtain idLists for connected features which have nearest distance = 0
         # for each input feature, identify its nearest feature with near_dist = 0 (e.g., connected features),
         # inIDList: list of ids of individual input features that have connected features
         # nearIDList:  this list contains the ids of their nearest features
         for row in cursor:
             inID = row.getValue("IN_FID")
-            nearID = row.getValue("NEAR_FID") 
-            nearDist = row.getValue("NEAR_DIST")    
-            if nearDist == 0:    
+            nearID = row.getValue("NEAR_FID")
+            nearDist = row.getValue("NEAR_DIST")
+            if nearDist == 0:
                 inIDList.append(inID)
                 nearIDList.append(nearID)
-                
-        del cursor,row
+
+        del cursor, row
         # obtain the number of features that are connected
         size = np.unique(np.asarray(inIDList)).size
 
-        if size == 0: # if no features are connected, simply copy the input featureclass to the outputs
-            arcpy.AddMessage('There are not connected features')
-            arcpy.Copy_management(inFeat,dissolveFeat2)
-        else: # if there are connected features, do the followings
-            arcpy.AddMessage(str(size) + ' total features are connected')
+        if (
+            size == 0
+        ):  # if no features are connected, simply copy the input featureclass to the outputs
+            arcpy.AddMessage("There are not connected features")
+            arcpy.Copy_management(inFeat, dissolveFeat2)
+        else:  # if there are connected features, do the followings
+            arcpy.AddMessage(str(size) + " total features are connected")
 
             # call the helper function to generate a new list of featID
             # the connected features will be assigned the same featID
-            featIDNewList = helper.findNewFeatIDs(inFeat,inIDList,nearIDList)
+            featIDNewList = helper.findNewFeatIDs(inFeat, inIDList, nearIDList)
             # update the featID field with the new ids
             cursor = arcpy.UpdateCursor(inFeat)
             i = 0
             for row in cursor:
                 featIDNew = featIDNewList[i]
-                row.setValue('featID',featIDNew)
+                row.setValue("featID", featIDNew)
                 cursor.updateRow(row)
                 i += 1
-            del cursor,row
+            del cursor, row
             dissolveFeat = "dissolveFeat"
             itemList.append(dissolveFeat)
             # dissolve all connected features that have same featIDs
-            arcpy.Dissolve_management(inFeat,dissolveFeat,'featID')
+            arcpy.Dissolve_management(inFeat, dissolveFeat, "featID")
             helper.calculateFeatID(dissolveFeat)
 
             # after converting dissolved features (multipart) to single-part features, the features connected
             # by shared point(s) will be un-dissolved
 
             # multipart to single-part
-            singlepartFeat = 'dissolve_singlepart'
+            singlepartFeat = "dissolve_singlepart"
             itemList.append(singlepartFeat)
-            arcpy.MultipartToSinglepart_management(dissolveFeat,singlepartFeat)
-            
+            arcpy.MultipartToSinglepart_management(dissolveFeat, singlepartFeat)
+
             # get the feature counts of the input features, the multipart dissolved features, and the single-part dissolved features
             inFeatCount = int(arcpy.GetCount_management(inFeat).getOutput(0))
-            dissolveFeatCount = int(arcpy.GetCount_management(dissolveFeat).getOutput(0))
-            singlepartFeatCount = int(arcpy.GetCount_management(singlepartFeat).getOutput(0))
+            dissolveFeatCount = int(
+                arcpy.GetCount_management(dissolveFeat).getOutput(0)
+            )
+            singlepartFeatCount = int(
+                arcpy.GetCount_management(singlepartFeat).getOutput(0)
+            )
 
-            if inFeatCount == singlepartFeatCount: # if all connected features are connected by shared points, copy the multipart dissolved features to outputs
-                arcpy.AddMessage('They are ' + str(size) + ' features having shared point(s). They have thus been connected.')
-                arcpy.Copy_management(dissolveFeat,dissolveFeat2)
-            elif dissolveFeatCount == singlepartFeatCount: # if all connected features are connected by shared borders, copy the input features to outputs
-                arcpy.AddMessage('They are ' + str(size) + ' features having shared border(s); They have thus not been connected.')
-                arcpy.Copy_management(inFeat,dissolveFeat2)
-            else: # if some features are connected by shared points and others are connected by shared borders,
+            if (
+                inFeatCount == singlepartFeatCount
+            ):  # if all connected features are connected by shared points, copy the multipart dissolved features to outputs
+                arcpy.AddMessage(
+                    "They are "
+                    + str(size)
+                    + " features having shared point(s). They have thus been connected."
+                )
+                arcpy.Copy_management(dissolveFeat, dissolveFeat2)
+            elif (
+                dissolveFeatCount == singlepartFeatCount
+            ):  # if all connected features are connected by shared borders, copy the input features to outputs
+                arcpy.AddMessage(
+                    "They are "
+                    + str(size)
+                    + " features having shared border(s); They have thus not been connected."
+                )
+                arcpy.Copy_management(inFeat, dissolveFeat2)
+            else:  # if some features are connected by shared points and others are connected by shared borders,
                 # 1. copy the single-part dissolved features as the output featureclass after merging features shared by borders
                 # 2. call the helper function get a count of features sharing borders and generate output featureclass after merging sharing points
-                dissolveFeat1 = 'dissolveFeat1'
+                dissolveFeat1 = "dissolveFeat1"
                 itemList.append(dissolveFeat1)
-                arcpy.Copy_management(singlepartFeat,dissolveFeat1)
-                count = helper.mergeFeatures(inFeat,dissolveFeat,dissolveFeat1,dissolveFeat2)
+                arcpy.Copy_management(singlepartFeat, dissolveFeat1)
+                count = helper.mergeFeatures(
+                    inFeat, dissolveFeat, dissolveFeat1, dissolveFeat2
+                )
                 count1 = size - count
-                arcpy.AddMessage("They are " + str(count) + ' features having shared border(s). They have thus not been connected.')
-                arcpy.AddMessage("They are " + str(count1) + ' features having shared point(s). They have thus been connected.')
+                arcpy.AddMessage(
+                    "They are "
+                    + str(count)
+                    + " features having shared border(s). They have thus not been connected."
+                )
+                arcpy.AddMessage(
+                    "They are "
+                    + str(count1)
+                    + " features having shared point(s). They have thus been connected."
+                )
 
             helper.calculateFeatID(dissolveFeat2)
             helper.deleteDataItems(itemList)
@@ -320,8 +376,8 @@ class Merge_Connected_Features_Tool(object):
 
 
 # This tool connects nearby linear bathymetric high features, based on one of the three algorithms.
-# The features to be connected satitify need to satisfy a number of conditions based on distance and orientation. 
-class Connect_Nearby_Linear_Features_Tool(object):
+# The features to be connected satitify need to satisfy a number of conditions based on distance and orientation.
+class Connect_Nearby_Linear_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Connect Nearby Linear Features Tool"
@@ -337,7 +393,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="inFeat",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -345,7 +402,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="distThreshold",
             datatype="GPLinearUnit",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -353,7 +411,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="angleThreshold",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # 4th parameter
         param3 = arcpy.Parameter(
@@ -361,7 +420,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="distWeight",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param3.value = 1
 
         # 5th parameter
@@ -370,7 +430,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="angleWeight",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 1
 
         # 6th parameter
@@ -379,10 +440,15 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="conOption",
             datatype="GPString",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param5.filter.type = "ValueList"
-        param5.filter.list = ['Mid points on Minimum Bounding Rectangle','Most distant points on feature','Mid points and Most distant points']
-        param5.value = 'Mid points on Minimum Bounding Rectangle'
+        param5.filter.list = [
+            "Mid points on Minimum Bounding Rectangle",
+            "Most distant points on feature",
+            "Mid points and Most distant points",
+        ]
+        param5.value = "Mid points on Minimum Bounding Rectangle"
 
         # 7th parameter
         param6 = arcpy.Parameter(
@@ -390,7 +456,8 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = "0 SquareMeters"
 
         # 8th parameter
@@ -399,26 +466,40 @@ class Connect_Nearby_Linear_Features_Tool(object):
             name="lwRatioT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param7.value = 0.9
-        
+
         # 9th parameter
         param8 = arcpy.Parameter(
             displayName="Output Connected Features",
             name="dissolveFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
-        
-      # 10th parameter, used to hold temporaray files
+            direction="Output",
+        )
+
+        # 10th parameter, used to hold temporaray files
         param9 = arcpy.Parameter(
             displayName="Temporary Folder",
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
-        
-        parameters = [param0, param1, param2, param3, param4, param5, param6, param7, param8, param9]
+            direction="Input",
+        )
+
+        parameters = [
+            param0,
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6,
+            param7,
+            param8,
+            param9,
+        ]
         return parameters
 
     def isLicensed(self):
@@ -429,7 +510,6 @@ class Connect_Nearby_Linear_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -440,7 +520,7 @@ class Connect_Nearby_Linear_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeat = parameters[0].valueAsText
         distThreshold = parameters[1].valueAsText
         angleThreshold = parameters[2].valueAsText
@@ -451,7 +531,7 @@ class Connect_Nearby_Linear_Features_Tool(object):
         lwRatioT = parameters[7].valueAsText
         dissolveFeat = parameters[8].valueAsText
         tempFolder = parameters[9].valueAsText
-                
+
         # enable helper function
         helper = helpers()
         inFeat = helper.convert_backslach_forwardslach(inFeat)
@@ -462,88 +542,102 @@ class Connect_Nearby_Linear_Features_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeat.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeat == lyr.name:
                         inFeat = helper.convert_backslach_forwardslach(lyr.dataSource)
 
-                        
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeat)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeat.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeat.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-
 
         # check that the output featureclass is in a correct format
         if dissolveFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output connected featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output connected featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-        distanceT =  distThreshold.split(" ")[0] # distance value 
-        linearUnit =  distThreshold.split(" ")[1] # distance unit       
+        distanceT = distThreshold.split(" ")[0]  # distance value
+        linearUnit = distThreshold.split(" ")[1]  # distance unit
         if linearUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown distance unit.")
             raise arcpy.ExecuteError
-        
+
         # check that the valid weights have been entered
         distWeight = float(distWeight)
         angleWeight = float(angleWeight)
         if (distWeight + angleWeight) == 0:
-            messages.addErrorMessage("You cann't assign a weight of zero to both distance and anlge!")
+            messages.addErrorMessage(
+                "You cann't assign a weight of zero to both distance and anlge!"
+            )
             raise arcpy.ExecuteError
 
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
+        areaUnit = areaThreshold.split(" ")[1]
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
-            raise arcpy.ExecuteError  
+            raise arcpy.ExecuteError
 
-        
-        workspaceName = inFeat[0:inFeat.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeat[0 : inFeat.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeat,'featID')
-
+            helper.addIDField(inFeat, "featID")
 
         itemList = []
         # generate bounding rectangle
         MbrFeat = "bounding_rectangle"
         itemList.append(MbrFeat)
-        arcpy.MinimumBoundingGeometry_management(inFeat, MbrFeat, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeat, MbrFeat, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         # add/calculate anlge field to inFeat
         field = "rectangle_Orientation"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Orientation" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "rectangle_Length"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Length" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "rectangle_Width"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Width" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "Length_Width_Ratio"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + MbrFeat + "." + "MBG_Length" + "! / !" + MbrFeat + "." + "MBG_Width" + "!" 
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        expression = (
+            "!"
+            + MbrFeat
+            + "."
+            + "MBG_Length"
+            + "! / !"
+            + MbrFeat
+            + "."
+            + "MBG_Width"
+            + "!"
+        )
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         # select a subset of input features to connect, based on the area threshold and length to width ratio threshold
         # this is to speed up the process when there are a large number of input features
@@ -553,18 +647,26 @@ class Connect_Nearby_Linear_Features_Tool(object):
         converter = helper.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThresholdValue)
 
-        whereClause = '(Length_Width_Ratio >= ' + str(lwRatioT) + ') And (Shape_Area >= ' + str(areaThreshold) + ')'
+        whereClause = (
+            "(Length_Width_Ratio >= "
+            + str(lwRatioT)
+            + ") And (Shape_Area >= "
+            + str(areaThreshold)
+            + ")"
+        )
         arcpy.AddMessage(whereClause)
-        arcpy.Select_analysis(inFeat,inFeat_selected1,whereClause)
+        arcpy.Select_analysis(inFeat, inFeat_selected1, whereClause)
 
         # generate the bounding rectangles for those selected features
         MbrFeat1 = "bounding_rectangle1"
         itemList.append(MbrFeat1)
-        arcpy.MinimumBoundingGeometry_management(inFeat_selected1, MbrFeat1, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeat_selected1, MbrFeat1, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
 
         inFeatCount = int(arcpy.GetCount_management(inFeat_selected1).getOutput(0))
         arcpy.AddMessage(str(inFeatCount) + " features selected for connection")
-        
+
         # generate direction points depending on the selected algorithm
         # Three algorithms
         # The 'Mid points on Minimum Bounding Rectangle' algorithm identifies the direction points (e.g., N and S)
@@ -576,29 +678,35 @@ class Connect_Nearby_Linear_Features_Tool(object):
         # convert rectangle sides to lines
         MbrLines1 = "MbrLines1"
         itemList.append(MbrLines1)
-        arcpy.SplitLine_management(MbrFeat1,MbrLines1)
+        arcpy.SplitLine_management(MbrFeat1, MbrLines1)
         arcpy.AddMessage("MbrLines1 done")
         # add these attributes to the MbrLines1
-        geometryFields = [['bearing','LINE_BEARING'],['MidX','CENTROID_X'],['MidY','CENTROID_Y']]
-        arcpy.CalculateGeometryAttributes_management(MbrLines1,geometryFields)
+        geometryFields = [
+            ["bearing", "LINE_BEARING"],
+            ["MidX", "CENTROID_X"],
+            ["MidY", "CENTROID_Y"],
+        ]
+        arcpy.CalculateGeometryAttributes_management(MbrLines1, geometryFields)
         # add a field for the purpose of subsequent selection
-        fieldName = 'angle_temp'
+        fieldName = "angle_temp"
         fieldType = "LONG"
         fieldPrecision = 15
-        arcpy.AddField_management(MbrLines1,fieldName,fieldType,fieldPrecision)
+        arcpy.AddField_management(MbrLines1, fieldName, fieldType, fieldPrecision)
         expression = "!bearing! - !rectangle_Orientation!"
-        arcpy.CalculateField_management(MbrLines1,fieldName,expression)
+        arcpy.CalculateField_management(MbrLines1, fieldName, expression)
         # select a subset of the lines: two lines from each bounding rectanlge (either N and S or E and W)
         MbrLines1_selected = "MbrLines1_selected"
         itemList.append(MbrLines1_selected)
-        whereClause = '((angle_temp <> 0) And (angle_temp <> 180))'
-        arcpy.Select_analysis(MbrLines1,MbrLines1_selected,whereClause)
+        whereClause = "((angle_temp <> 0) And (angle_temp <> 180))"
+        arcpy.Select_analysis(MbrLines1, MbrLines1_selected, whereClause)
         arcpy.AddMessage("MbrLines1 selection done")
         # identify and assign these lines with directional flags
-        fieldName = 'direction'
-        fieldType = 'text'
+        fieldName = "direction"
+        fieldType = "text"
         fieldLength = 10
-        arcpy.AddField_management(MbrLines1_selected,fieldName,fieldType,field_length=fieldLength)
+        arcpy.AddField_management(
+            MbrLines1_selected, fieldName, fieldType, field_length=fieldLength
+        )
 
         expression = "getDirection(round(!rectangle_Orientation!,2),!angle_temp!)"
 
@@ -622,25 +730,32 @@ def getDirection(angle1,angle2):
         return 'S'
     if(angle1 > 135) & (angle1 <= 180) & (angle2 == -90):
         return 'N'"""
-        
-        arcpy.CalculateField_management(MbrLines1_selected, fieldName, expression, "PYTHON_9.3", codeblock)
+
+        arcpy.CalculateField_management(
+            MbrLines1_selected, fieldName, expression, "PYTHON_9.3", codeblock
+        )
         # add and calculate an "angle" field
-        fieldName = 'angle'
-        fieldType = 'DOUBLE'
+        fieldName = "angle"
+        fieldType = "DOUBLE"
         filedPrecision = 15
         fieldScale = 6
-        arcpy.AddField_management(MbrLines1_selected,fieldName,fieldType,fieldPrecision,fieldScale)
+        arcpy.AddField_management(
+            MbrLines1_selected, fieldName, fieldType, fieldPrecision, fieldScale
+        )
         expression = "!rectangle_Orientation!"
-        arcpy.CalculateField_management(MbrLines1_selected, fieldName, expression, "PYTHON_9.3")
-        
-        
-        pointFeat = 'pointFeat'
+        arcpy.CalculateField_management(
+            MbrLines1_selected, fieldName, expression, "PYTHON_9.3"
+        )
+
+        pointFeat = "pointFeat"
         itemList.append(pointFeat)
         # generate directional points featureclass(es) according to the selected algorithm
-        if conOption == 'Mid points on Minimum Bounding Rectangle':
+        if conOption == "Mid points on Minimum Bounding Rectangle":
             # MidX and MidY fields already given the coordinate of the middle point
-            arcpy.XYTableToPoint_management(MbrLines1_selected,pointFeat,'MidX','MidY','#',MbrLines1_selected)
-            fieldsToKept = ['featID','angle','direction']
+            arcpy.XYTableToPoint_management(
+                MbrLines1_selected, pointFeat, "MidX", "MidY", "#", MbrLines1_selected
+            )
+            fieldsToKept = ["featID", "angle", "direction"]
             fieldsToDelete = []
             fields = arcpy.ListFields(pointFeat)
             for field in fields:
@@ -648,15 +763,21 @@ def getDirection(angle1,angle2):
                     if not field.name in fieldsToKept:
                         fieldsToDelete.append(field.name)
 
-            arcpy.DeleteField_management(pointFeat,fieldsToDelete)            
-        elif conOption == 'Most distant points on feature':
-            helper.getDirectionPoints(inFeat_selected1,MbrLines1_selected,tempFolder,pointFeat)
-        elif conOption == 'Mid points and Most distant points': # generate two set of direction points, one set using Mid points option, the other set using Most distant option
-            pointFeat1 = 'pointFeat1'
+            arcpy.DeleteField_management(pointFeat, fieldsToDelete)
+        elif conOption == "Most distant points on feature":
+            helper.getDirectionPoints(
+                inFeat_selected1, MbrLines1_selected, tempFolder, pointFeat
+            )
+        elif (
+            conOption == "Mid points and Most distant points"
+        ):  # generate two set of direction points, one set using Mid points option, the other set using Most distant option
+            pointFeat1 = "pointFeat1"
             itemList.append(pointFeat1)
 
-            arcpy.XYTableToPoint_management(MbrLines1_selected,pointFeat,'MidX','MidY','#',MbrLines1_selected)
-            fieldsToKept = ['featID','angle','direction']
+            arcpy.XYTableToPoint_management(
+                MbrLines1_selected, pointFeat, "MidX", "MidY", "#", MbrLines1_selected
+            )
+            fieldsToKept = ["featID", "angle", "direction"]
             fieldsToDelete = []
             fields = arcpy.ListFields(pointFeat)
             for field in fields:
@@ -664,55 +785,56 @@ def getDirection(angle1,angle2):
                     if not field.name in fieldsToKept:
                         fieldsToDelete.append(field.name)
 
-            arcpy.DeleteField_management(pointFeat,fieldsToDelete)
+            arcpy.DeleteField_management(pointFeat, fieldsToDelete)
 
-            helper.getDirectionPoints(inFeat_selected1,MbrLines1_selected,tempFolder,pointFeat1)
+            helper.getDirectionPoints(
+                inFeat_selected1, MbrLines1_selected, tempFolder, pointFeat1
+            )
 
         arcpy.AddMessage("direction points done at " + str(datetime.now()))
-        
+
         # separate points based on directions
-        pointFeatN = pointFeat + '_N'
-        pointFeatS = pointFeat + '_S'
-        pointFeatE = pointFeat + '_E'
-        pointFeatW = pointFeat + '_W'
+        pointFeatN = pointFeat + "_N"
+        pointFeatS = pointFeat + "_S"
+        pointFeatE = pointFeat + "_E"
+        pointFeatW = pointFeat + "_W"
         itemList.append(pointFeatN)
         itemList.append(pointFeatS)
         itemList.append(pointFeatE)
         itemList.append(pointFeatW)
-        
+
         whereClause = "direction = 'N'"
-        arcpy.Select_analysis(pointFeat,pointFeatN,whereClause)
+        arcpy.Select_analysis(pointFeat, pointFeatN, whereClause)
         whereClause = "direction = 'S'"
-        arcpy.Select_analysis(pointFeat,pointFeatS,whereClause)
+        arcpy.Select_analysis(pointFeat, pointFeatS, whereClause)
         whereClause = "direction = 'E'"
-        arcpy.Select_analysis(pointFeat,pointFeatE,whereClause)
+        arcpy.Select_analysis(pointFeat, pointFeatE, whereClause)
         whereClause = "direction = 'W'"
-        arcpy.Select_analysis(pointFeat,pointFeatW,whereClause)
+        arcpy.Select_analysis(pointFeat, pointFeatW, whereClause)
         # For this combined option, generate another set of direction point features
-        if conOption == 'Mid points and Most distant points': 
-            pointFeatN1 = pointFeat1 + '_N'
-            pointFeatS1 = pointFeat1 + '_S'
-            pointFeatE1 = pointFeat1 + '_E'
-            pointFeatW1 = pointFeat1 + '_W'
+        if conOption == "Mid points and Most distant points":
+            pointFeatN1 = pointFeat1 + "_N"
+            pointFeatS1 = pointFeat1 + "_S"
+            pointFeatE1 = pointFeat1 + "_E"
+            pointFeatW1 = pointFeat1 + "_W"
             itemList.append(pointFeatN1)
             itemList.append(pointFeatS1)
             itemList.append(pointFeatE1)
             itemList.append(pointFeatW1)
-            
-            whereClause = "direction = 'N'"
-            arcpy.Select_analysis(pointFeat1,pointFeatN1,whereClause)
-            whereClause = "direction = 'S'"
-            arcpy.Select_analysis(pointFeat1,pointFeatS1,whereClause)
-            whereClause = "direction = 'E'"
-            arcpy.Select_analysis(pointFeat1,pointFeatE1,whereClause)
-            whereClause = "direction = 'W'"
-            arcpy.Select_analysis(pointFeat1,pointFeatW1,whereClause)            
 
+            whereClause = "direction = 'N'"
+            arcpy.Select_analysis(pointFeat1, pointFeatN1, whereClause)
+            whereClause = "direction = 'S'"
+            arcpy.Select_analysis(pointFeat1, pointFeatS1, whereClause)
+            whereClause = "direction = 'E'"
+            arcpy.Select_analysis(pointFeat1, pointFeatE1, whereClause)
+            whereClause = "direction = 'W'"
+            arcpy.Select_analysis(pointFeat1, pointFeatW1, whereClause)
 
         # generate links based on the direction points
         # For the combined option, create four sets of links
         # For the other two options, just need to create one set of links
-        if conOption == 'Mid points and Most distant points':            
+        if conOption == "Mid points and Most distant points":
             linksFeatWE = "linkWE"
             linksFeatSN = "linkSN"
             linksFeatWN = "linkWN"
@@ -726,27 +848,56 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeatSW)
             itemList.append(linksFeatEN)
             # This ArcGIS function create links from each origin to each destination
-            # Note that the tool parameter 'distance threshold' is used in the search_distance parameter to limit the number of destination points from each origin point 
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatE, linksFeatWE,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatN, linksFeatSN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatN, linksFeatWN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatE, linksFeatSE,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatW, linksFeatSW,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatE, pointFeatN, linksFeatEN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
+            # Note that the tool parameter 'distance threshold' is used in the search_distance parameter to limit the number of destination points from each origin point
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatE,
+                linksFeatWE,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatN,
+                linksFeatSN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatN,
+                linksFeatWN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatE,
+                linksFeatSE,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatW,
+                linksFeatSW,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatE,
+                pointFeatN,
+                linksFeatEN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
 
-            helper.calculateFeatIDAngle(linksFeatWE,pointFeatW,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatSN,pointFeatS,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatWN,pointFeatW,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatSE,pointFeatS,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatSW,pointFeatS,pointFeatW)
-            helper.calculateFeatIDAngle(linksFeatEN,pointFeatE,pointFeatN)
-
+            helper.calculateFeatIDAngle(linksFeatWE, pointFeatW, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatSN, pointFeatS, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatWN, pointFeatW, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatSE, pointFeatS, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatSW, pointFeatS, pointFeatW)
+            helper.calculateFeatIDAngle(linksFeatEN, pointFeatE, pointFeatN)
 
             linksFeatW1E1 = "linkW1E1"
             linksFeatS1N1 = "linkS1N1"
@@ -760,26 +911,56 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeatS1E1)
             itemList.append(linksFeatS1W1)
             itemList.append(linksFeatE1N1)
-            
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW1, pointFeatE1, linksFeatW1E1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatN1, linksFeatS1N1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW1, pointFeatN1, linksFeatW1N1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatE1, linksFeatS1E1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatW1, linksFeatS1W1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatE1, pointFeatN1, linksFeatE1N1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
 
-            helper.calculateFeatIDAngle(linksFeatW1E1,pointFeatW1,pointFeatE1)
-            helper.calculateFeatIDAngle(linksFeatS1N1,pointFeatS1,pointFeatN1)
-            helper.calculateFeatIDAngle(linksFeatW1N1,pointFeatW1,pointFeatN1)
-            helper.calculateFeatIDAngle(linksFeatS1E1,pointFeatS1,pointFeatE1)
-            helper.calculateFeatIDAngle(linksFeatS1W1,pointFeatS1,pointFeatW1)
-            helper.calculateFeatIDAngle(linksFeatE1N1,pointFeatE1,pointFeatN1)
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW1,
+                pointFeatE1,
+                linksFeatW1E1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatN1,
+                linksFeatS1N1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW1,
+                pointFeatN1,
+                linksFeatW1N1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatE1,
+                linksFeatS1E1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatW1,
+                linksFeatS1W1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatE1,
+                pointFeatN1,
+                linksFeatE1N1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+
+            helper.calculateFeatIDAngle(linksFeatW1E1, pointFeatW1, pointFeatE1)
+            helper.calculateFeatIDAngle(linksFeatS1N1, pointFeatS1, pointFeatN1)
+            helper.calculateFeatIDAngle(linksFeatW1N1, pointFeatW1, pointFeatN1)
+            helper.calculateFeatIDAngle(linksFeatS1E1, pointFeatS1, pointFeatE1)
+            helper.calculateFeatIDAngle(linksFeatS1W1, pointFeatS1, pointFeatW1)
+            helper.calculateFeatIDAngle(linksFeatE1N1, pointFeatE1, pointFeatN1)
 
             linksFeatWE1 = "linkWE1"
             linksFeatSN1 = "linkSN1"
@@ -793,28 +974,56 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeatSE1)
             itemList.append(linksFeatSW1)
             itemList.append(linksFeatEN1)
-            
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatE1, linksFeatWE1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatN1, linksFeatSN1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatN1, linksFeatWN1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatE1, linksFeatSE1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatW1, linksFeatSW1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatE, pointFeatN1, linksFeatEN1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
 
-            helper.calculateFeatIDAngle(linksFeatWE1,pointFeatW,pointFeatE1)
-            helper.calculateFeatIDAngle(linksFeatSN1,pointFeatS,pointFeatN1)
-            helper.calculateFeatIDAngle(linksFeatWN1,pointFeatW,pointFeatN1)
-            helper.calculateFeatIDAngle(linksFeatSE1,pointFeatS,pointFeatE1)
-            helper.calculateFeatIDAngle(linksFeatSW1,pointFeatS,pointFeatW1)
-            helper.calculateFeatIDAngle(linksFeatEN1,pointFeatE,pointFeatN1)
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatE1,
+                linksFeatWE1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatN1,
+                linksFeatSN1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatN1,
+                linksFeatWN1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatE1,
+                linksFeatSE1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatW1,
+                linksFeatSW1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatE,
+                pointFeatN1,
+                linksFeatEN1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
 
-            
+            helper.calculateFeatIDAngle(linksFeatWE1, pointFeatW, pointFeatE1)
+            helper.calculateFeatIDAngle(linksFeatSN1, pointFeatS, pointFeatN1)
+            helper.calculateFeatIDAngle(linksFeatWN1, pointFeatW, pointFeatN1)
+            helper.calculateFeatIDAngle(linksFeatSE1, pointFeatS, pointFeatE1)
+            helper.calculateFeatIDAngle(linksFeatSW1, pointFeatS, pointFeatW1)
+            helper.calculateFeatIDAngle(linksFeatEN1, pointFeatE, pointFeatN1)
 
             linksFeatW1E = "linkW1E"
             linksFeatS1N = "linkS1N"
@@ -828,41 +1037,70 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeatS1E)
             itemList.append(linksFeatS1W)
             itemList.append(linksFeatE1N)
-            
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW1, pointFeatE, linksFeatW1E,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatN, linksFeatS1N,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW1, pointFeatN, linksFeatW1N,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatE, linksFeatS1E,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS1, pointFeatW, linksFeatS1W,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatE1, pointFeatN, linksFeatE1N,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
 
-            helper.calculateFeatIDAngle(linksFeatW1E,pointFeatW1,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatS1N,pointFeatS1,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatW1N,pointFeatW1,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatS1E,pointFeatS1,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatS1W,pointFeatS1,pointFeatW)
-            helper.calculateFeatIDAngle(linksFeatE1N,pointFeatE1,pointFeatN)
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW1,
+                pointFeatE,
+                linksFeatW1E,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatN,
+                linksFeatS1N,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW1,
+                pointFeatN,
+                linksFeatW1N,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatE,
+                linksFeatS1E,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS1,
+                pointFeatW,
+                linksFeatS1W,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatE1,
+                pointFeatN,
+                linksFeatE1N,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
 
+            helper.calculateFeatIDAngle(linksFeatW1E, pointFeatW1, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatS1N, pointFeatS1, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatW1N, pointFeatW1, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatS1E, pointFeatS1, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatS1W, pointFeatS1, pointFeatW)
+            helper.calculateFeatIDAngle(linksFeatE1N, pointFeatE1, pointFeatN)
 
             # merge four sets together
-            fList = [linksFeatW1E1,linksFeatWE1,linksFeatW1E]
-            arcpy.Append_management(fList,linksFeatWE)
-            fList = [linksFeatS1N1,linksFeatSN1,linksFeatS1N]
-            arcpy.Append_management(fList,linksFeatSN)
-            fList = [linksFeatW1N1,linksFeatWN1,linksFeatW1N]
-            arcpy.Append_management(fList,linksFeatWN)
-            fList = [linksFeatS1E1,linksFeatSE1,linksFeatS1E]
-            arcpy.Append_management(fList,linksFeatSE)
-            fList = [linksFeatS1W1,linksFeatSW1,linksFeatS1W]
-            arcpy.Append_management(fList,linksFeatSW)
-            fList = [linksFeatE1N1,linksFeatEN1,linksFeatE1N]
-            arcpy.Append_management(fList,linksFeatEN)
+            fList = [linksFeatW1E1, linksFeatWE1, linksFeatW1E]
+            arcpy.Append_management(fList, linksFeatWE)
+            fList = [linksFeatS1N1, linksFeatSN1, linksFeatS1N]
+            arcpy.Append_management(fList, linksFeatSN)
+            fList = [linksFeatW1N1, linksFeatWN1, linksFeatW1N]
+            arcpy.Append_management(fList, linksFeatWN)
+            fList = [linksFeatS1E1, linksFeatSE1, linksFeatS1E]
+            arcpy.Append_management(fList, linksFeatSE)
+            fList = [linksFeatS1W1, linksFeatSW1, linksFeatS1W]
+            arcpy.Append_management(fList, linksFeatSW)
+            fList = [linksFeatE1N1, linksFeatEN1, linksFeatE1N]
+            arcpy.Append_management(fList, linksFeatEN)
         else:
             # create only one set of links
             linksFeatWE = "linkWE"
@@ -877,29 +1115,59 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeatSE)
             itemList.append(linksFeatSW)
             itemList.append(linksFeatEN)
-            
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatE, linksFeatWE,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatN, linksFeatSN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatW, pointFeatN, linksFeatWN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatE, linksFeatSE,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatS, pointFeatW, linksFeatSW,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeatE, pointFeatN, linksFeatEN,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
 
-            helper.calculateFeatIDAngle(linksFeatWE,pointFeatW,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatSN,pointFeatS,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatWN,pointFeatW,pointFeatN)
-            helper.calculateFeatIDAngle(linksFeatSE,pointFeatS,pointFeatE)
-            helper.calculateFeatIDAngle(linksFeatSW,pointFeatS,pointFeatW)
-            helper.calculateFeatIDAngle(linksFeatEN,pointFeatE,pointFeatN)
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatE,
+                linksFeatWE,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatN,
+                linksFeatSN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatW,
+                pointFeatN,
+                linksFeatWN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatE,
+                linksFeatSE,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatS,
+                pointFeatW,
+                linksFeatSW,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeatE,
+                pointFeatN,
+                linksFeatEN,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+
+            helper.calculateFeatIDAngle(linksFeatWE, pointFeatW, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatSN, pointFeatS, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatWN, pointFeatW, pointFeatN)
+            helper.calculateFeatIDAngle(linksFeatSE, pointFeatS, pointFeatE)
+            helper.calculateFeatIDAngle(linksFeatSW, pointFeatS, pointFeatW)
+            helper.calculateFeatIDAngle(linksFeatEN, pointFeatE, pointFeatN)
 
         arcpy.AddMessage("initial links generated at " + str(datetime.now()))
-        
+
         # For each link direction (e.g., SN indicates from South to North), select two subsets of links based on certain criteria.
         # The criteria are determined by the distance threshold, angle threshold, distance weight and angle weight.
         # There are six link directions (SN, WN, SE, WE, SW and EN) to consider, when connecting neary features.
@@ -907,44 +1175,97 @@ def getDirection(angle1,angle2):
         outLinkFeatSN2 = "linkSN_2"
         itemList.append(outLinkFeatSN1)
         itemList.append(outLinkFeatSN2)
-        helper.doLinks1(linksFeatSN,outLinkFeatSN1,outLinkFeatSN2,distanceT,angleThreshold,distWeight,angleWeight,'SN')
+        helper.doLinks1(
+            linksFeatSN,
+            outLinkFeatSN1,
+            outLinkFeatSN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SN",
+        )
 
         outLinkFeatWN1 = "linkWN_1"
-        outLinkFeatWN2 = "linkWN_2"        
+        outLinkFeatWN2 = "linkWN_2"
         itemList.append(outLinkFeatWN1)
         itemList.append(outLinkFeatWN2)
-        helper.doLinks1(linksFeatWN,outLinkFeatWN1,outLinkFeatWN2,distanceT,angleThreshold,distWeight,angleWeight,'WN')
+        helper.doLinks1(
+            linksFeatWN,
+            outLinkFeatWN1,
+            outLinkFeatWN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "WN",
+        )
 
         outLinkFeatSE1 = "linkSE_1"
         outLinkFeatSE2 = "linkSE_2"
         itemList.append(outLinkFeatSE1)
         itemList.append(outLinkFeatSE2)
-        helper.doLinks1(linksFeatSE,outLinkFeatSE1,outLinkFeatSE2,distanceT,angleThreshold,distWeight,angleWeight,'SE')
+        helper.doLinks1(
+            linksFeatSE,
+            outLinkFeatSE1,
+            outLinkFeatSE2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SE",
+        )
 
         outLinkFeatWE1 = "linkWE_1"
         outLinkFeatWE2 = "linkWE_2"
         itemList.append(outLinkFeatWE1)
         itemList.append(outLinkFeatWE2)
-        helper.doLinks1(linksFeatWE,outLinkFeatWE1,outLinkFeatWE2,distanceT,angleThreshold,distWeight,angleWeight,'WE')
-        
+        helper.doLinks1(
+            linksFeatWE,
+            outLinkFeatWE1,
+            outLinkFeatWE2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "WE",
+        )
+
         outLinkFeatSW1 = "linkSW_1"
         outLinkFeatSW2 = "linkSW_2"
         itemList.append(outLinkFeatSW1)
         itemList.append(outLinkFeatSW2)
-        helper.doLinks1(linksFeatSW,outLinkFeatSW1,outLinkFeatSW2,distanceT,angleThreshold,distWeight,angleWeight,'SW')
-        
+        helper.doLinks1(
+            linksFeatSW,
+            outLinkFeatSW1,
+            outLinkFeatSW2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SW",
+        )
+
         outLinkFeatEN1 = "linkEN_1"
         outLinkFeatEN2 = "linkEN_2"
         itemList.append(outLinkFeatEN1)
         itemList.append(outLinkFeatEN2)
-        helper.doLinks1(linksFeatEN,outLinkFeatEN1,outLinkFeatEN2,distanceT,angleThreshold,distWeight,angleWeight,'EN')
+        helper.doLinks1(
+            linksFeatEN,
+            outLinkFeatEN1,
+            outLinkFeatEN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "EN",
+        )
 
         arcpy.AddMessage("do links done at " + str(datetime.now()))
 
-
-##        # note that the input link features could also be those resulted from the first set of links 
-##        # e.g. outLinkFeatSN1, outLinkFeatWN1, outLinkFeatSE1, outLinkFeatWE1, outLinkFeatSW1, outLinkFeatEN1
-##        # the result would be slightly different
+        ##        # note that the input link features could also be those resulted from the first set of links
+        ##        # e.g. outLinkFeatSN1, outLinkFeatWN1, outLinkFeatSE1, outLinkFeatWE1, outLinkFeatSW1, outLinkFeatEN1
+        ##        # the result would be slightly different
 
         # create initial lists
         linksFeatList = []
@@ -954,19 +1275,40 @@ def getDirection(angle1,angle2):
         linksFeatList.append(outLinkFeatWE2)
         linksFeatList.append(outLinkFeatSW2)
         linksFeatList.append(outLinkFeatEN2)
-        
-        featID1List,featID2List,featIDListList,distList,angleList = helper.createLists(linksFeatList)
+
+        featID1List, featID2List, featIDListList, distList, angleList = (
+            helper.createLists(linksFeatList)
+        )
         arcpy.AddMessage("create lists done")
         # updates ids list and other lists when multiple elements share either "from" or "to" points
         # each outList1 element contains a list of featIDs
-        list1,list2,outList1,list3,list4 = helper.doLists(featID1List,featID2List,
-                                                   featIDListList,distList,angleList,distanceT,angleThreshold,distWeight,angleWeight)
+        list1, list2, outList1, list3, list4 = helper.doLists(
+            featID1List,
+            featID2List,
+            featIDListList,
+            distList,
+            angleList,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+        )
         arcpy.AddMessage("do lists done at " + str(datetime.now()))
         # further updates ids list when multiple elements connected through sharing "from" and "to" points
         # each outList2 element contains a list of featIDs
-        outList2 = helper.doLists1(list1,list2,outList1,list3,list4,distanceT,angleThreshold,distWeight,angleWeight)
+        outList2 = helper.doLists1(
+            list1,
+            list2,
+            outList1,
+            list3,
+            list4,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+        )
         arcpy.AddMessage("do lists1 done at " + str(datetime.now()))
-        
+
         # merge elements of outList2 where appropriate (e.g., share at least one common id)
         leng1 = len(helper.getUnique(list(flatten(outList2))))
         arcpy.AddMessage("leng1:" + str(leng1))
@@ -979,55 +1321,54 @@ def getDirection(angle1,angle2):
             outList = helper.mergeList(outList)
             leng2 = len(list(flatten(outList)))
         arcpy.AddMessage("merge elements done at " + str(datetime.now()))
-            
+
         # get the original featID list
         cursor = arcpy.SearchCursor(inFeat)
         featIDList = []
         for row in cursor:
             featID = row.getValue("featID")
             featIDList.append(featID)
-        del cursor,row    
-
+        del cursor, row
 
         ### assign a same featID to features that have been identified as to be connected
         featIDNewList = featIDList.copy()
-        for tempList in outList:    
+        for tempList in outList:
             indexList = []
             featureIDList = []
             for idv in tempList:
                 index = featIDList.index(idv)
-                featureID = featIDList[index]        
+                featureID = featIDList[index]
                 indexList.append(index)
                 featureIDList.append(featureID)
             for index in indexList:
                 featIDNewList[index] = featureIDList[0]
 
-        inFeat1 = 'inFeat1'
+        inFeat1 = "inFeat1"
         itemList.append(inFeat1)
-        arcpy.Copy_management(inFeat,inFeat1)
+        arcpy.Copy_management(inFeat, inFeat1)
         # update the featID
         cursor = arcpy.UpdateCursor(inFeat1)
         i = 0
         for row in cursor:
             featIDNew = featIDNewList[i]
-            row.setValue('featID',featIDNew)
+            row.setValue("featID", featIDNew)
             cursor.updateRow(row)
             i += 1
-        del cursor,row
+        del cursor, row
         # merge connected features to generate output featureclass
-        arcpy.Dissolve_management(inFeat1,dissolveFeat,'featID')
-        arcpy.AddMessage('merge done')
+        arcpy.Dissolve_management(inFeat1, dissolveFeat, "featID")
+        arcpy.AddMessage("merge done")
         # call the helper function to re-calculate featID the output featureclass
         helper.calculateFeatID(dissolveFeat)
         # delete temporary data
-        helper.deleteDataItems(itemList)          
-        
+        helper.deleteDataItems(itemList)
+
         return
 
 
 # This tool connects nearby linear bathymetric high features, based on one of the three algorithms.
-# The features to be connected satitify need to satisfy a number of conditions based on distance and orientation. 
-class Connect_Nearby_Linear_HF_Features_Tool(object):
+# The features to be connected satitify need to satisfy a number of conditions based on distance and orientation.
+class Connect_Nearby_Linear_HF_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Connect Nearby Linear HF Features Tool"
@@ -1043,7 +1384,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="inFeat",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -1051,7 +1393,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -1059,7 +1402,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="distThreshold",
             datatype="GPLinearUnit",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # 4th parameter
         param3 = arcpy.Parameter(
@@ -1067,7 +1411,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="angleThreshold",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # 5th parameter
         param4 = arcpy.Parameter(
@@ -1075,7 +1420,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="distWeight",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 1
 
         # 6th parameter
@@ -1084,7 +1430,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="angleWeight",
             datatype="GPDouble",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 1
 
         # 7th parameter
@@ -1093,10 +1440,15 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="conOption",
             datatype="GPString",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param6.filter.type = "ValueList"
-        param6.filter.list = ['Mid points on Minimum Bounding Rectangle','Most distant points on feature','Mid points and Most distant points']
-        param6.value = 'Mid points on Minimum Bounding Rectangle'
+        param6.filter.list = [
+            "Mid points on Minimum Bounding Rectangle",
+            "Most distant points on feature",
+            "Mid points and Most distant points",
+        ]
+        param6.value = "Mid points on Minimum Bounding Rectangle"
 
         # 8th parameter
         param7 = arcpy.Parameter(
@@ -1104,7 +1456,8 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param7.value = "0 SquareMeters"
 
         # 9th parameter
@@ -1113,26 +1466,41 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
             name="lwRatioT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param8.value = 0.9
-        
+
         # 10th parameter
         param9 = arcpy.Parameter(
             displayName="Output Connected Features",
             name="dissolveFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
-        
-      # 11th parameter, used to hold temporaray files
+            direction="Output",
+        )
+
+        # 11th parameter, used to hold temporaray files
         param10 = arcpy.Parameter(
             displayName="Temporary Folder",
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
-        
-        parameters = [param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10]
+            direction="Input",
+        )
+
+        parameters = [
+            param0,
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6,
+            param7,
+            param8,
+            param9,
+            param10,
+        ]
         return parameters
 
     def isLicensed(self):
@@ -1143,7 +1511,6 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -1154,7 +1521,7 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeat = parameters[0].valueAsText
         inBathy = parameters[1].valueAsText
         distThreshold = parameters[2].valueAsText
@@ -1166,7 +1533,7 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         lwRatioT = parameters[8].valueAsText
         dissolveFeat = parameters[9].valueAsText
         tempFolder = parameters[10].valueAsText
-                
+
         # enable helper function
         helper = helpers()
         inFeat = helper.convert_backslach_forwardslach(inFeat)
@@ -1177,7 +1544,7 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeat.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeat == lyr.name:
@@ -1187,106 +1554,127 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
                         inBathy = helper.convert_backslach_forwardslach(lyr.dataSource)
-                        
-       # check that the input feature class is in a correct format
+
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeat)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeat.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeat.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
 
         # check that the output featureclass is in a correct format
         if dissolveFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output connected featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output connected featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
-        distanceT =  distThreshold.split(" ")[0] # distance value 
-        linearUnit =  distThreshold.split(" ")[1] # distance unit       
+        distanceT = distThreshold.split(" ")[0]  # distance value
+        linearUnit = distThreshold.split(" ")[1]  # distance unit
         if linearUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown distance unit.")
             raise arcpy.ExecuteError
-        
+
         # check that the valid weights have been entered
         distWeight = float(distWeight)
         angleWeight = float(angleWeight)
         if (distWeight + angleWeight) == 0:
-            messages.addErrorMessage("You cann't assign a weight of zero to both distance and anlge!")
+            messages.addErrorMessage(
+                "You cann't assign a weight of zero to both distance and anlge!"
+            )
             raise arcpy.ExecuteError
 
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
+        areaUnit = areaThreshold.split(" ")[1]
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
-            raise arcpy.ExecuteError  
+            raise arcpy.ExecuteError
 
-        
-        workspaceName = inFeat[0:inFeat.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeat[0 : inFeat.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeat,'featID')
-
+            helper.addIDField(inFeat, "featID")
 
         itemList = []
         # generate bounding rectangle
         MbrFeat = "bounding_rectangle"
         itemList.append(MbrFeat)
-        arcpy.MinimumBoundingGeometry_management(inFeat, MbrFeat, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeat, MbrFeat, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         # add/calculate anlge field to inFeat
         field = "rectangle_Orientation"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Orientation" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "rectangle_Length"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Length" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "rectangle_Width"
         inID = "featID"
         joinID = "featID"
         expression = "!" + MbrFeat + "." + "MBG_Width" + "!"
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         field = "Length_Width_Ratio"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + MbrFeat + "." + "MBG_Length" + "! / !" + MbrFeat + "." + "MBG_Width" + "!" 
-        helper.addField(inFeat,MbrFeat,field,inID,joinID,expression)
+        expression = (
+            "!"
+            + MbrFeat
+            + "."
+            + "MBG_Length"
+            + "! / !"
+            + MbrFeat
+            + "."
+            + "MBG_Width"
+            + "!"
+        )
+        helper.addField(inFeat, MbrFeat, field, inID, joinID, expression)
 
         # select a subset of input features to connect, based on the area threshold and length to width ratio threshold
         # this is to speed up the process when there are a large number of input features
@@ -1296,18 +1684,26 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         converter = helper.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThresholdValue)
 
-        whereClause = '(Length_Width_Ratio >= ' + str(lwRatioT) + ') And (Shape_Area >= ' + str(areaThreshold) + ')'
+        whereClause = (
+            "(Length_Width_Ratio >= "
+            + str(lwRatioT)
+            + ") And (Shape_Area >= "
+            + str(areaThreshold)
+            + ")"
+        )
         arcpy.AddMessage(whereClause)
-        arcpy.Select_analysis(inFeat,inFeat_selected1,whereClause)
+        arcpy.Select_analysis(inFeat, inFeat_selected1, whereClause)
 
         # generate the bounding rectangles for those selected features
         MbrFeat1 = "bounding_rectangle1"
         itemList.append(MbrFeat1)
-        arcpy.MinimumBoundingGeometry_management(inFeat_selected1, MbrFeat1, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeat_selected1, MbrFeat1, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
 
         inFeatCount = int(arcpy.GetCount_management(inFeat_selected1).getOutput(0))
         arcpy.AddMessage(str(inFeatCount) + " features selected for connection")
-        
+
         # generate direction points depending on the selected algorithm
         # Three algorithms
         # The 'Mid points on Minimum Bounding Rectangle' algorithm identifies the direction points (e.g., N and S)
@@ -1319,29 +1715,35 @@ class Connect_Nearby_Linear_HF_Features_Tool(object):
         # convert rectangle sides to lines
         MbrLines1 = "MbrLines1"
         itemList.append(MbrLines1)
-        arcpy.SplitLine_management(MbrFeat1,MbrLines1)
+        arcpy.SplitLine_management(MbrFeat1, MbrLines1)
         arcpy.AddMessage("MbrLines1 done")
         # add these attributes to the MbrLines1
-        geometryFields = [['bearing','LINE_BEARING'],['MidX','CENTROID_X'],['MidY','CENTROID_Y']]
-        arcpy.CalculateGeometryAttributes_management(MbrLines1,geometryFields)
+        geometryFields = [
+            ["bearing", "LINE_BEARING"],
+            ["MidX", "CENTROID_X"],
+            ["MidY", "CENTROID_Y"],
+        ]
+        arcpy.CalculateGeometryAttributes_management(MbrLines1, geometryFields)
         # add a field for the purpose of subsequent selection
-        fieldName = 'angle_temp'
+        fieldName = "angle_temp"
         fieldType = "LONG"
         fieldPrecision = 15
-        arcpy.AddField_management(MbrLines1,fieldName,fieldType,fieldPrecision)
+        arcpy.AddField_management(MbrLines1, fieldName, fieldType, fieldPrecision)
         expression = "!bearing! - !rectangle_Orientation!"
-        arcpy.CalculateField_management(MbrLines1,fieldName,expression)
+        arcpy.CalculateField_management(MbrLines1, fieldName, expression)
         # select a subset of the lines: two lines from each bounding rectanlge (either N and S or E and W)
         MbrLines1_selected = "MbrLines1_selected"
         itemList.append(MbrLines1_selected)
-        whereClause = '((angle_temp <> 0) And (angle_temp <> 180))'
-        arcpy.Select_analysis(MbrLines1,MbrLines1_selected,whereClause)
+        whereClause = "((angle_temp <> 0) And (angle_temp <> 180))"
+        arcpy.Select_analysis(MbrLines1, MbrLines1_selected, whereClause)
         arcpy.AddMessage("MbrLines1 selection done")
         # identify and assign these lines with directional flags
-        fieldName = 'direction'
-        fieldType = 'text'
+        fieldName = "direction"
+        fieldType = "text"
         fieldLength = 10
-        arcpy.AddField_management(MbrLines1_selected,fieldName,fieldType,field_length=fieldLength)
+        arcpy.AddField_management(
+            MbrLines1_selected, fieldName, fieldType, field_length=fieldLength
+        )
 
         expression = "getDirection(round(!rectangle_Orientation!,2),!angle_temp!)"
 
@@ -1365,38 +1767,58 @@ def getDirection(angle1,angle2):
         return 'S'
     if(angle1 > 135) & (angle1 <= 180) & (angle2 == -90):
         return 'N'"""
-        
-        arcpy.CalculateField_management(MbrLines1_selected, fieldName, expression, "PYTHON_9.3", codeblock)
+
+        arcpy.CalculateField_management(
+            MbrLines1_selected, fieldName, expression, "PYTHON_9.3", codeblock
+        )
         # add and calculate an "angle" field
-        fieldName = 'angle'
-        fieldType = 'DOUBLE'
+        fieldName = "angle"
+        fieldType = "DOUBLE"
         filedPrecision = 15
         fieldScale = 6
-        arcpy.AddField_management(MbrLines1_selected,fieldName,fieldType,fieldPrecision,fieldScale)
+        arcpy.AddField_management(
+            MbrLines1_selected, fieldName, fieldType, fieldPrecision, fieldScale
+        )
         expression = "!rectangle_Orientation!"
-        arcpy.CalculateField_management(MbrLines1_selected, fieldName, expression, "PYTHON_9.3")
+        arcpy.CalculateField_management(
+            MbrLines1_selected, fieldName, expression, "PYTHON_9.3"
+        )
 
         # expand inBathy
         # This is to ensure that the point(s) at the edge of bathymetry grid have depth values
         inFocal = inBathy + "_focal"
         itemList.append(inFocal)
-        outFocalStat = FocalStatistics(inBathy, NbrRectangle(3,3,"CELL"),"MEAN","DATA")
+        outFocalStat = FocalStatistics(
+            inBathy, NbrRectangle(3, 3, "CELL"), "MEAN", "DATA"
+        )
         outFocalStat.save(inFocal)
         # mosaic to new raster
         mosaicBathy = "mosaicBathy"
         itemList.append(mosaicBathy)
-        inputRasters = [inBathy,inFocal]  
-        arcpy.MosaicToNewRaster_management(inputRasters,workspaceName, mosaicBathy, inBathy, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
+        inputRasters = [inBathy, inFocal]
+        arcpy.MosaicToNewRaster_management(
+            inputRasters,
+            workspaceName,
+            mosaicBathy,
+            inBathy,
+            "32_BIT_FLOAT",
+            "#",
+            "1",
+            "FIRST",
+            "FIRST",
+        )
         arcpy.AddMessage("mosaic done")
-        
+
         mosaicBathy = "mosaicBathy"
-        pointFeat = 'pointFeat'
+        pointFeat = "pointFeat"
         itemList.append(pointFeat)
         # generate directional points featureclass
-        if conOption == 'Mid points on Minimum Bounding Rectangle':
+        if conOption == "Mid points on Minimum Bounding Rectangle":
             # MidX and MidY fields already given the coordinate of the middle point
-            arcpy.XYTableToPoint_management(MbrLines1_selected,pointFeat,'MidX','MidY','#',MbrLines1_selected)
-            fieldsToKept = ['featID','angle','direction']
+            arcpy.XYTableToPoint_management(
+                MbrLines1_selected, pointFeat, "MidX", "MidY", "#", MbrLines1_selected
+            )
+            fieldsToKept = ["featID", "angle", "direction"]
             fieldsToDelete = []
             fields = arcpy.ListFields(pointFeat)
             for field in fields:
@@ -1404,39 +1826,45 @@ def getDirection(angle1,angle2):
                     if not field.name in fieldsToKept:
                         fieldsToDelete.append(field.name)
 
-            arcpy.DeleteField_management(pointFeat,fieldsToDelete)
+            arcpy.DeleteField_management(pointFeat, fieldsToDelete)
             arcpy.AddXY_management(pointFeat)
-            
+
             pointFeat2 = "pointFeat2"
             itemList.append(pointFeat2)
             # add two fields to incidate head and foot locations
-            helper.toFHpoints(pointFeat,mosaicBathy,tempFolder,pointFeat2)
+            helper.toFHpoints(pointFeat, mosaicBathy, tempFolder, pointFeat2)
 
             pointFeat2F = "pointFeat2F"
             pointFeat2H = "pointFeat2H"
             itemList.append(pointFeat2F)
             itemList.append(pointFeat2H)
             whereClause = "location = 'F'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2F,whereClause)
+            arcpy.Select_analysis(pointFeat2, pointFeat2F, whereClause)
             whereClause = "location = 'H'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2H,whereClause)
-        elif conOption == 'Most distant points on feature':
-            helper.getDirectionPoints(inFeat_selected1,MbrLines1_selected,tempFolder,pointFeat)
+            arcpy.Select_analysis(pointFeat2, pointFeat2H, whereClause)
+        elif conOption == "Most distant points on feature":
+            helper.getDirectionPoints(
+                inFeat_selected1, MbrLines1_selected, tempFolder, pointFeat
+            )
             pointFeat2 = "pointFeat2"
             itemList.append(pointFeat2)
-            helper.toFHpoints(pointFeat,mosaicBathy,tempFolder,pointFeat2)
-            
+            helper.toFHpoints(pointFeat, mosaicBathy, tempFolder, pointFeat2)
+
             pointFeat2F = "pointFeat2F"
             pointFeat2H = "pointFeat2H"
             itemList.append(pointFeat2F)
             itemList.append(pointFeat2H)
             whereClause = "location = 'F'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2F,whereClause)
+            arcpy.Select_analysis(pointFeat2, pointFeat2F, whereClause)
             whereClause = "location = 'H'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2H,whereClause)
-        elif conOption == 'Mid points and Most distant points': # generate two set of direction points, one set using Mid points option, the other set using Most distant option
-            arcpy.XYTableToPoint_management(MbrLines1_selected,pointFeat,'MidX','MidY','#',MbrLines1_selected)
-            fieldsToKept = ['featID','angle','direction']
+            arcpy.Select_analysis(pointFeat2, pointFeat2H, whereClause)
+        elif (
+            conOption == "Mid points and Most distant points"
+        ):  # generate two set of direction points, one set using Mid points option, the other set using Most distant option
+            arcpy.XYTableToPoint_management(
+                MbrLines1_selected, pointFeat, "MidX", "MidY", "#", MbrLines1_selected
+            )
+            fieldsToKept = ["featID", "angle", "direction"]
             fieldsToDelete = []
             fields = arcpy.ListFields(pointFeat)
             for field in fields:
@@ -1444,45 +1872,43 @@ def getDirection(angle1,angle2):
                     if not field.name in fieldsToKept:
                         fieldsToDelete.append(field.name)
 
-            arcpy.DeleteField_management(pointFeat,fieldsToDelete)
+            arcpy.DeleteField_management(pointFeat, fieldsToDelete)
             arcpy.AddXY_management(pointFeat)
-            
+
             pointFeat2 = "pointFeat2"
             itemList.append(pointFeat2)
-            helper.toFHpoints(pointFeat,mosaicBathy,tempFolder,pointFeat2)
+            helper.toFHpoints(pointFeat, mosaicBathy, tempFolder, pointFeat2)
             pointFeat2F = "pointFeat2F"
             pointFeat2H = "pointFeat2H"
             itemList.append(pointFeat2F)
             itemList.append(pointFeat2H)
             whereClause = "location = 'F'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2F,whereClause)
+            arcpy.Select_analysis(pointFeat2, pointFeat2F, whereClause)
             whereClause = "location = 'H'"
-            arcpy.Select_analysis(pointFeat2,pointFeat2H,whereClause)
+            arcpy.Select_analysis(pointFeat2, pointFeat2H, whereClause)
 
-            
-            pointFeat1 = 'pointFeat1'
+            pointFeat1 = "pointFeat1"
             itemList.append(pointFeat1)
-            helper.getDirectionPoints(inFeat_selected1,MbrLines1_selected,tempFolder,pointFeat1)
+            helper.getDirectionPoints(
+                inFeat_selected1, MbrLines1_selected, tempFolder, pointFeat1
+            )
             pointFeat3 = "pointFeat3"
             itemList.append(pointFeat3)
-            helper.toFHpoints(pointFeat1,mosaicBathy,tempFolder,pointFeat3)
+            helper.toFHpoints(pointFeat1, mosaicBathy, tempFolder, pointFeat3)
 
             pointFeat3F = "pointFeat3F"
             pointFeat3H = "pointFeat3H"
             itemList.append(pointFeat3F)
             itemList.append(pointFeat3H)
             whereClause = "location = 'F'"
-            arcpy.Select_analysis(pointFeat3,pointFeat3F,whereClause)
+            arcpy.Select_analysis(pointFeat3, pointFeat3F, whereClause)
             whereClause = "location = 'H'"
-            arcpy.Select_analysis(pointFeat3,pointFeat3H,whereClause)
-
+            arcpy.Select_analysis(pointFeat3, pointFeat3H, whereClause)
 
         arcpy.AddMessage("direction points done at " + str(datetime.now()))
 
-        
-
         # create and process links
-        if conOption == 'Mid points and Most distant points':
+        if conOption == "Mid points and Most distant points":
             # create four sets of links
             linksFeat1 = "links1"
             linksFeat2 = "links2"
@@ -1493,14 +1919,34 @@ def getDirection(angle1,angle2):
             itemList.append(linksFeat3)
             itemList.append(linksFeat4)
 
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeat2F, pointFeat2H, linksFeat1,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeat2F, pointFeat3H, linksFeat2,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeat3F, pointFeat3H, linksFeat3,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeat3F, pointFeat2H, linksFeat4,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeat2F,
+                pointFeat2H,
+                linksFeat1,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeat2F,
+                pointFeat3H,
+                linksFeat2,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeat3F,
+                pointFeat3H,
+                linksFeat3,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeat3F,
+                pointFeat2H,
+                linksFeat4,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
 
             outLinksFeat1 = "links1_selected"
             outLinksFeat2 = "links2_selected"
@@ -1511,171 +1957,283 @@ def getDirection(angle1,angle2):
             itemList.append(outLinksFeat3)
             itemList.append(outLinksFeat4)
             # select a subset of links
-            helper.selectLinks(linksFeat1,pointFeat2F,pointFeat2H,outLinksFeat1)
-            helper.selectLinks(linksFeat2,pointFeat2F,pointFeat3H,outLinksFeat2)
-            helper.selectLinks(linksFeat3,pointFeat3F,pointFeat3H,outLinksFeat3)
-            helper.selectLinks(linksFeat4,pointFeat3F,pointFeat2H,outLinksFeat4)
+            helper.selectLinks(linksFeat1, pointFeat2F, pointFeat2H, outLinksFeat1)
+            helper.selectLinks(linksFeat2, pointFeat2F, pointFeat3H, outLinksFeat2)
+            helper.selectLinks(linksFeat3, pointFeat3F, pointFeat3H, outLinksFeat3)
+            helper.selectLinks(linksFeat4, pointFeat3F, pointFeat2H, outLinksFeat4)
 
-            helper.calculateFeatIDAngle(outLinksFeat1,pointFeat2F,pointFeat2H)
-            helper.calculateFeatIDAngle(outLinksFeat2,pointFeat2F,pointFeat3H)
-            helper.calculateFeatIDAngle(outLinksFeat3,pointFeat3F,pointFeat3H)
-            helper.calculateFeatIDAngle(outLinksFeat4,pointFeat3F,pointFeat2H)
-            
+            helper.calculateFeatIDAngle(outLinksFeat1, pointFeat2F, pointFeat2H)
+            helper.calculateFeatIDAngle(outLinksFeat2, pointFeat2F, pointFeat3H)
+            helper.calculateFeatIDAngle(outLinksFeat3, pointFeat3F, pointFeat3H)
+            helper.calculateFeatIDAngle(outLinksFeat4, pointFeat3F, pointFeat2H)
+
             arcpy.AddMessage("initial links generated at " + str(datetime.now()))
             # merge links
             outLinksFeat = "links_selected"
             itemList.append(outLinksFeat)
-            fcList = [outLinksFeat1,outLinksFeat2,outLinksFeat3,outLinksFeat4]
-            arcpy.Merge_management(fcList,outLinksFeat)
+            fcList = [outLinksFeat1, outLinksFeat2, outLinksFeat3, outLinksFeat4]
+            arcpy.Merge_management(fcList, outLinksFeat)
         else:
             # create only one set of links
             linksFeat = "links_all"
             itemList.append(linksFeat)
-            
-            arcpy.analysis.GenerateOriginDestinationLinks(pointFeat2F, pointFeat2H, linksFeat,
-                                                         search_distance=distanceT,distance_unit=linearUnit)
+
+            arcpy.analysis.GenerateOriginDestinationLinks(
+                pointFeat2F,
+                pointFeat2H,
+                linksFeat,
+                search_distance=distanceT,
+                distance_unit=linearUnit,
+            )
             outLinksFeat = "links_selected"
             itemList.append(outLinksFeat)
             # select a subset of links
-            helper.selectLinks(linksFeat,pointFeat2F,pointFeat2H,outLinksFeat)
-            helper.calculateFeatIDAngle(outLinksFeat,pointFeat2F,pointFeat2H)
+            helper.selectLinks(linksFeat, pointFeat2F, pointFeat2H, outLinksFeat)
+            helper.calculateFeatIDAngle(outLinksFeat, pointFeat2F, pointFeat2H)
 
             arcpy.AddMessage("initial links generated at " + str(datetime.now()))
-            
 
         # split the links into 12 subsets based on the from and to directions
         linksSN = "linksSN"
         itemList.append(linksSN)
         whereClause = "fromDirection = 'S' And toDirection = 'N'"
-        arcpy.Select_analysis(outLinksFeat,linksSN,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksSN, whereClause)
 
         linksNS = "linksNS"
         itemList.append(linksNS)
         whereClause = "fromDirection = 'N' And toDirection = 'S'"
-        arcpy.Select_analysis(outLinksFeat,linksNS,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksNS, whereClause)
 
         linksEW = "linksEW"
         itemList.append(linksEW)
         whereClause = "fromDirection = 'E' And toDirection = 'W'"
-        arcpy.Select_analysis(outLinksFeat,linksEW,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksEW, whereClause)
 
         linksWE = "linksWE"
         itemList.append(linksWE)
         whereClause = "fromDirection = 'W' And toDirection = 'E'"
-        arcpy.Select_analysis(outLinksFeat,linksWE,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksWE, whereClause)
 
         linksEN = "linksEN"
         itemList.append(linksEN)
         whereClause = "fromDirection = 'E' And toDirection = 'N'"
-        arcpy.Select_analysis(outLinksFeat,linksEN,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksEN, whereClause)
 
         linksNE = "linksNE"
         itemList.append(linksNE)
         whereClause = "fromDirection = 'N' And toDirection = 'E'"
-        arcpy.Select_analysis(outLinksFeat,linksNE,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksNE, whereClause)
 
         linksSW = "linksSW"
         itemList.append(linksSW)
         whereClause = "fromDirection = 'S' And toDirection = 'W'"
-        arcpy.Select_analysis(outLinksFeat,linksSW,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksSW, whereClause)
 
         linksWS = "linksWS"
         itemList.append(linksWS)
         whereClause = "fromDirection = 'W' And toDirection = 'S'"
-        arcpy.Select_analysis(outLinksFeat,linksWS,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksWS, whereClause)
 
         linksSE = "linksSE"
         itemList.append(linksSE)
         whereClause = "fromDirection = 'S' And toDirection = 'E'"
-        arcpy.Select_analysis(outLinksFeat,linksSE,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksSE, whereClause)
 
         linksES = "linksES"
         itemList.append(linksES)
         whereClause = "fromDirection = 'E' And toDirection = 'S'"
-        arcpy.Select_analysis(outLinksFeat,linksES,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksES, whereClause)
 
         linksWN = "linksWN"
         itemList.append(linksWN)
         whereClause = "fromDirection = 'W' And toDirection = 'N'"
-        arcpy.Select_analysis(outLinksFeat,linksWN,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksWN, whereClause)
 
         linksNW = "linksNW"
         itemList.append(linksNW)
         whereClause = "fromDirection = 'N' And toDirection = 'W'"
-        arcpy.Select_analysis(outLinksFeat,linksNW,whereClause)
+        arcpy.Select_analysis(outLinksFeat, linksNW, whereClause)
 
         # further process the links
         outLinkFeatSN1 = "linksSN_1"
         outLinkFeatSN2 = "linksSN_2"
         itemList.append(outLinkFeatSN1)
         itemList.append(outLinkFeatSN2)
-        helper.doLinks1(linksSN,outLinkFeatSN1,outLinkFeatSN2,distanceT,angleThreshold,distWeight,angleWeight,'SN')
-        
+        helper.doLinks1(
+            linksSN,
+            outLinkFeatSN1,
+            outLinkFeatSN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SN",
+        )
+
         outLinkFeatNS1 = "linksNS_1"
         outLinkFeatNS2 = "linksNS_2"
         itemList.append(outLinkFeatNS1)
         itemList.append(outLinkFeatNS2)
-        helper.doLinks1(linksNS,outLinkFeatNS1,outLinkFeatNS2,distanceT,angleThreshold,distWeight,angleWeight,'NS')
-        
+        helper.doLinks1(
+            linksNS,
+            outLinkFeatNS1,
+            outLinkFeatNS2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "NS",
+        )
+
         outLinkFeatWE1 = "linksWE_1"
         outLinkFeatWE2 = "linksWE_2"
         itemList.append(outLinkFeatWE1)
         itemList.append(outLinkFeatWE2)
-        helper.doLinks1(linksWE,outLinkFeatWE1,outLinkFeatWE2,distanceT,angleThreshold,distWeight,angleWeight,'WE')
+        helper.doLinks1(
+            linksWE,
+            outLinkFeatWE1,
+            outLinkFeatWE2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "WE",
+        )
 
         outLinkFeatEW1 = "linksEW_1"
         outLinkFeatEW2 = "linksEW_2"
         itemList.append(outLinkFeatEW1)
         itemList.append(outLinkFeatEW2)
-        helper.doLinks1(linksEW,outLinkFeatEW1,outLinkFeatEW2,distanceT,angleThreshold,distWeight,angleWeight,'EW')
+        helper.doLinks1(
+            linksEW,
+            outLinkFeatEW1,
+            outLinkFeatEW2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "EW",
+        )
 
         outLinkFeatEN1 = "linksEN_1"
         outLinkFeatEN2 = "linksEN_2"
         itemList.append(outLinkFeatEN1)
         itemList.append(outLinkFeatEN2)
-        helper.doLinks1(linksEN,outLinkFeatEN1,outLinkFeatEN2,distanceT,angleThreshold,distWeight,angleWeight,'EN')
+        helper.doLinks1(
+            linksEN,
+            outLinkFeatEN1,
+            outLinkFeatEN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "EN",
+        )
 
         outLinkFeatNE1 = "linksNE_1"
         outLinkFeatNE2 = "linksNE_2"
         itemList.append(outLinkFeatNE1)
         itemList.append(outLinkFeatNE2)
-        helper.doLinks1(linksNE,outLinkFeatNE1,outLinkFeatNE2,distanceT,angleThreshold,distWeight,angleWeight,'NE')
+        helper.doLinks1(
+            linksNE,
+            outLinkFeatNE1,
+            outLinkFeatNE2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "NE",
+        )
 
         outLinkFeatSW1 = "linksSW_1"
         outLinkFeatSW2 = "linksSW_2"
         itemList.append(outLinkFeatSW1)
         itemList.append(outLinkFeatSW2)
-        helper.doLinks1(linksSW,outLinkFeatSW1,outLinkFeatSW2,distanceT,angleThreshold,distWeight,angleWeight,'SW')
+        helper.doLinks1(
+            linksSW,
+            outLinkFeatSW1,
+            outLinkFeatSW2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SW",
+        )
 
         outLinkFeatWS1 = "linksWS_1"
         outLinkFeatWS2 = "linksWS_2"
         itemList.append(outLinkFeatWS1)
         itemList.append(outLinkFeatWS2)
-        helper.doLinks1(linksWS,outLinkFeatWS1,outLinkFeatWS2,distanceT,angleThreshold,distWeight,angleWeight,'WS')
+        helper.doLinks1(
+            linksWS,
+            outLinkFeatWS1,
+            outLinkFeatWS2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "WS",
+        )
 
         outLinkFeatSE1 = "linksSE_1"
         outLinkFeatSE2 = "linksSE_2"
         itemList.append(outLinkFeatSE1)
         itemList.append(outLinkFeatSE2)
-        helper.doLinks1(linksSE,outLinkFeatSE1,outLinkFeatSE2,distanceT,angleThreshold,distWeight,angleWeight,'SE')
+        helper.doLinks1(
+            linksSE,
+            outLinkFeatSE1,
+            outLinkFeatSE2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "SE",
+        )
 
         outLinkFeatES1 = "linksES_1"
         outLinkFeatES2 = "linksES_2"
         itemList.append(outLinkFeatES1)
         itemList.append(outLinkFeatES2)
-        helper.doLinks1(linksES,outLinkFeatES1,outLinkFeatES2,distanceT,angleThreshold,distWeight,angleWeight,'ES')
+        helper.doLinks1(
+            linksES,
+            outLinkFeatES1,
+            outLinkFeatES2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "ES",
+        )
 
         outLinkFeatWN1 = "linksWN_1"
         outLinkFeatWN2 = "linksWN_2"
         itemList.append(outLinkFeatWN1)
         itemList.append(outLinkFeatWN2)
-        helper.doLinks1(linksWN,outLinkFeatWN1,outLinkFeatWN2,distanceT,angleThreshold,distWeight,angleWeight,'WN')
-        
+        helper.doLinks1(
+            linksWN,
+            outLinkFeatWN1,
+            outLinkFeatWN2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "WN",
+        )
+
         outLinkFeatNW1 = "linksNW_1"
         outLinkFeatNW2 = "linksNW_2"
         itemList.append(outLinkFeatNW1)
         itemList.append(outLinkFeatNW2)
-        helper.doLinks1(linksNW,outLinkFeatNW1,outLinkFeatNW2,distanceT,angleThreshold,distWeight,angleWeight,'NW')
+        helper.doLinks1(
+            linksNW,
+            outLinkFeatNW1,
+            outLinkFeatNW2,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+            "NW",
+        )
 
         # create initial lists
         linkFeatList = []
@@ -1691,20 +2249,40 @@ def getDirection(angle1,angle2):
         linkFeatList.append(outLinkFeatES2)
         linkFeatList.append(outLinkFeatWN2)
         linkFeatList.append(outLinkFeatNW2)
-        featID1List,featID2List,featIDListList,distList,angleList = helper.createLists(linkFeatList)
+        featID1List, featID2List, featIDListList, distList, angleList = (
+            helper.createLists(linkFeatList)
+        )
         arcpy.AddMessage("create lists done")
-
 
         # updates ids list and other lists when multiple elements share either "from" or "to" points
         # each outList1 element contains a list of featIDs
-        list1,list2,outList1,list3,list4 = helper.doLists(featID1List,featID2List,
-                                                   featIDListList,distList,angleList,distanceT,angleThreshold,distWeight,angleWeight)
+        list1, list2, outList1, list3, list4 = helper.doLists(
+            featID1List,
+            featID2List,
+            featIDListList,
+            distList,
+            angleList,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+        )
         arcpy.AddMessage("do lists done at " + str(datetime.now()))
         # further updates ids list when multiple elements connected through sharing "from" and "to" points
         # each outList2 element contains a list of featIDs
-        outList2 = helper.doLists1(list1,list2,outList1,list3,list4,distanceT,angleThreshold,distWeight,angleWeight)
+        outList2 = helper.doLists1(
+            list1,
+            list2,
+            outList1,
+            list3,
+            list4,
+            distanceT,
+            angleThreshold,
+            distWeight,
+            angleWeight,
+        )
         arcpy.AddMessage("do lists1 done at " + str(datetime.now()))
-        
+
         # merge elements of outList2 where appropriate (e.g., share at least one common id)
         leng1 = len(helper.getUnique(list(flatten(outList2))))
         arcpy.AddMessage("leng1:" + str(leng1))
@@ -1717,60 +2295,58 @@ def getDirection(angle1,angle2):
             outList = helper.mergeList(outList)
             leng2 = len(list(flatten(outList)))
         arcpy.AddMessage("merge elements done at " + str(datetime.now()))
-            
+
         # get the original featID list
         cursor = arcpy.SearchCursor(inFeat)
         featIDList = []
         for row in cursor:
             featID = row.getValue("featID")
             featIDList.append(featID)
-        del cursor,row    
-
+        del cursor, row
 
         ### assign a same featID to features that have been identified as to be connected
         featIDNewList = featIDList.copy()
-        for tempList in outList:    
+        for tempList in outList:
             indexList = []
             featureIDList = []
             for idv in tempList:
                 index = featIDList.index(idv)
-                featureID = featIDList[index]        
+                featureID = featIDList[index]
                 indexList.append(index)
                 featureIDList.append(featureID)
             for index in indexList:
                 featIDNewList[index] = featureIDList[0]
 
-        inFeat1 = 'inFeat1'
+        inFeat1 = "inFeat1"
         itemList.append(inFeat1)
-        arcpy.Copy_management(inFeat,inFeat1)
+        arcpy.Copy_management(inFeat, inFeat1)
         # update the featID
         cursor = arcpy.UpdateCursor(inFeat1)
         i = 0
         for row in cursor:
             featIDNew = featIDNewList[i]
-            row.setValue('featID',featIDNew)
+            row.setValue("featID", featIDNew)
             cursor.updateRow(row)
             i += 1
-        del cursor,row
+        del cursor, row
         # merge connected features to generate output featureclass
-        arcpy.Dissolve_management(inFeat1,dissolveFeat,'featID')
-        arcpy.AddMessage('merge done')
+        arcpy.Dissolve_management(inFeat1, dissolveFeat, "featID")
+        arcpy.AddMessage("merge done")
         # call the helper function to re-calculate featID the output featureclass
         helper.calculateFeatID(dissolveFeat)
         # delete temporary data
-##        helper.deleteDataItems(itemList)          
-        
+        ##        helper.deleteDataItems(itemList)
+
         return
 
 
-
 # the helper functions are defined here
-class helpers(object):
+class helpers:
 
     # This function calculates a converter value for the input area unit. The base unit is "SquareMeters".
-    def areaUnitConverter(self,inAreaUnit):
+    def areaUnitConverter(self, inAreaUnit):
         # inAreaUnit: input Area Unit
-        
+
         if inAreaUnit == "Acres":
             converter = 4046.86
         elif inAreaUnit == "Ares":
@@ -1794,52 +2370,52 @@ class helpers(object):
         elif inAreaUnit == "SquareMillimeters":
             converter = 0.000001
         elif inAreaUnit == "SquareYards":
-            converter = 0.83613       
+            converter = 0.83613
 
         return converter
-    
-    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
-        # inText: input path
-        
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
 
-        inText = inText.replace('\\','/')
+    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
+    def convert_backslach_forwardslach(self, inText):
+        # inText: input path
+
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
+
+        inText = inText.replace("\\", "/")
         return inText
 
     # This function gets unique values in a list
-    def getUnique(self,l1):
+    def getUnique(self, l1):
         # l1: input list
-        
+
         l2 = np.unique(np.asarray(l1)).tolist()
         return l2
 
     # This function gets the common element(s) between two lists and returns the number of these common element(s)
-    def calculateCommon(self,l1,l2):
+    def calculateCommon(self, l1, l2):
         # l1: first input list
         # l2: second input list
-        
+
         l1_set = set(l1)
         intersection = l1_set.intersection(l2)
         return len(intersection)
 
     # This function gets unique values in a 2-D list
-    def getUnique2D(self,l1):
+    def getUnique2D(self, l1):
         # l1: input 2-D list
-        
-        l2 = np.unique(np.asarray(l1),axis=0).tolist()
+
+        l2 = np.unique(np.asarray(l1), axis=0).tolist()
         return l2
 
     # This function deletes all intermediate data items
-    def deleteDataItems(self,inDataList):
+    def deleteDataItems(self, inDataList):
         # inDataList: a list of data items to be deleted
-        
+
         if len(inDataList) == 0:
             arcpy.AddMessage("no data item in the list")
 
@@ -1850,33 +2426,32 @@ class helpers(object):
         return
 
     # This function adds a featID field with unique ID values
-    def addIDField(self,inFeat,fieldName):
-        # inFeat: input featureclass (or table)       
-        # fieldName: the field in the inFeat to be calculated from the joinFeat        
-        
+    def addIDField(self, inFeat, fieldName):
+        # inFeat: input featureclass (or table)
+        # fieldName: the field in the inFeat to be calculated from the joinFeat
+
         fieldType = "LONG"
         fieldPrecision = 15
-        
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
-        
+
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(inFeat, fieldName, fieldType, fieldPrecision)
 
         expression = "!OBJECTID!"
 
         arcpy.CalculateField_management(inFeat, fieldName, expression, "PYTHON_9.3")
-        
+
         arcpy.AddMessage(fieldName + " added and calculated")
         return
-    
+
     # This function adds and calculates unique featID field
-    def calculateFeatID(self,inFeat):
+    def calculateFeatID(self, inFeat):
         # inFeat: input features
-        
+
         fieldName = "featID"
         fieldType = "Long"
         fieldPrecision = 6
@@ -1884,44 +2459,45 @@ class helpers(object):
         field_names = [f.name for f in fields]
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
-        else:    
-            arcpy.AddField_management(inFeat,fieldName,fieldType,field_precision=fieldPrecision)
+        else:
+            arcpy.AddField_management(
+                inFeat, fieldName, fieldType, field_precision=fieldPrecision
+            )
         expression = "!OBJECTID!"
-        arcpy.CalculateField_management(inFeat,fieldName,expression)
+        arcpy.CalculateField_management(inFeat, fieldName, expression)
         return
 
-
-    def calculateFeatIDAngle(self,inLinkFeat,originPointFeat,destPointFeat):
+    def calculateFeatIDAngle(self, inLinkFeat, originPointFeat, destPointFeat):
         field1 = "featID1"
-        field2 = "angle1" # orientation of the origin features
+        field2 = "angle1"  # orientation of the origin features
         inID = "ORIG_FID"
         joinID = "OBJECTID"
         expression = "!" + originPointFeat + "." + "featID" + "!"
-        self.addLongField(inLinkFeat,originPointFeat,field1,inID,joinID,expression)
+        self.addLongField(inLinkFeat, originPointFeat, field1, inID, joinID, expression)
         expression = "!" + originPointFeat + "." + "angle" + "!"
-        self.addField(inLinkFeat,originPointFeat,field2,inID,joinID,expression)
+        self.addField(inLinkFeat, originPointFeat, field2, inID, joinID, expression)
 
         field1 = "featID2"
-        field2 = "angle2" # orientation of the destination features
+        field2 = "angle2"  # orientation of the destination features
         inID = "DEST_FID"
         joinID = "OBJECTID"
         expression = "!" + destPointFeat + "." + "featID" + "!"
-        self.addLongField(inLinkFeat,destPointFeat,field1,inID,joinID,expression)
+        self.addLongField(inLinkFeat, destPointFeat, field1, inID, joinID, expression)
         expression = "!" + destPointFeat + "." + "angle" + "!"
-        self.addField(inLinkFeat,destPointFeat,field2,inID,joinID,expression)
+        self.addField(inLinkFeat, destPointFeat, field2, inID, joinID, expression)
 
         return
-    
+
     # This function deletes a feild from input featureclass
-    def deleteField(self,inFeat,fieldName):
+    def deleteField(self, inFeat, fieldName):
         # inFeat: input featureclass
         # fieldName: field to be deleted
-        
+
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be deleted")
-            arcpy.DeleteField_management(inFeat,[fieldName])
+            arcpy.DeleteField_management(inFeat, [fieldName])
         else:
             arcpy.AddMessage(fieldName + " does not exist")
 
@@ -1929,11 +2505,11 @@ class helpers(object):
 
     # This function finds the polygon features that connect with each other (e.g, near_dist == 0)
     # and generate a new list of featID, with the connected features being assigned the same featID
-    def findNewFeatIDs(self,inFeat,inIDList,nearIDList):
+    def findNewFeatIDs(self, inFeat, inIDList, nearIDList):
         # inFeat: input polygon features
         # inIDList: list of ids of individual input features that have connected features
         # nearIDList:  this list contains the ids of their nearest features
-        
+
         cursor = arcpy.SearchCursor(inFeat)
         objectIDList = []
         featIDList = []
@@ -1942,10 +2518,12 @@ class helpers(object):
             featID = row.getValue("featID")
             featIDList.append(featID)
             objectIDList.append(objectID)
-        del cursor,row    
+        del cursor, row
 
-        tempListList = [] # each element list contains ids of connected features e.g. [[1, 3], [1, 2, 3], [4, 9], [2, 3, 5], [6, 13]], first iteration
-        anotherList = [] # flatten tempListList
+        tempListList = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 3], [1, 2, 3], [4, 9], [2, 3, 5], [6, 13]], first iteration
+        anotherList = []  # flatten tempListList
         inIDArr = np.asarray(inIDList)
         inIDArrU = np.unique(inIDArr)
         i = 0
@@ -1956,50 +2534,53 @@ class helpers(object):
             if inID not in anotherList:
                 # get the id of its connected feature
                 nearID = nearIDList[i]
-                tempList.append(inID)  
+                tempList.append(inID)
                 tempList.append(nearID)
-                tempArr = np.where(inIDArr == nearID)[0] # the index position of the nearID
+                tempArr = np.where(inIDArr == nearID)[
+                    0
+                ]  # the index position of the nearID
 
                 for el in tempArr:
                     tempList.append(nearIDList[el])
-                tempList = np.unique(np.asarray(tempList)).tolist()            
+                tempList = np.unique(np.asarray(tempList)).tolist()
                 tempListList.append(tempList)
                 # use the flatten function to convert 2-D list into 1-D list
                 anotherList = list(flatten(tempListList))
             i += 1
 
-
-        tempListList1 = [] # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]], final results after more merge from tempListList
-        tempListListCopy = tempListList.copy() # deep copy
+        tempListList1 = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]], final results after more merge from tempListList
+        tempListListCopy = tempListList.copy()  # deep copy
         while len(tempListList) > 0:
             tempList = tempListList[0]
             tempListCopy = tempList.copy()
-            
+
             for tempList1 in tempListListCopy:
                 # call the helper function to find the number of common elements bewtween the two lists
-                leng = self.calculateCommon(tempListCopy,tempList1)
+                leng = self.calculateCommon(tempListCopy, tempList1)
                 if leng > 0:
                     tempListList.remove(tempList1)
                     for el in tempList1:
-                        tempListCopy.append(el)           
+                        tempListCopy.append(el)
                     # call the helper function to get the unique values within a list
                     tempList3 = self.getUnique(tempListCopy)
                     tempListCopy = tempList3.copy()
-                    
+
             list1 = list(flatten(tempListCopy))
             list2 = self.getUnique(list1)
-            tempListList1.append(list2)    
+            tempListList1.append(list2)
             tempListListCopy = tempListList.copy()
 
         # generate a new list of featID
         # the connected features are assigned the same featID
         featIDNewList = featIDList.copy()
-        for tempList in tempListList1:    
+        for tempList in tempListList1:
             indexList = []
             featureIDList = []
             for idv in tempList:
                 index = objectIDList.index(idv)
-                featureID = featIDList[index]        
+                featureID = featIDList[index]
                 indexList.append(index)
                 featureIDList.append(featureID)
             for index in indexList:
@@ -2010,48 +2591,56 @@ class helpers(object):
     # These features satitify the following conditions: 1. the distance between the head of one feature and the foot of another feature is less than a user-defined threshold,
     # 2.the two nearby features align in orientation with the intersecting angle < 45 degree.
     # Finally, this function generate a new list of featID, with the connected features being assigned the same featID
-    def findNewFeatIDs_1(self,inFeat,headFeat,footFeat,distThreshold):
+    def findNewFeatIDs_1(self, inFeat, headFeat, footFeat, distThreshold):
         # inFeat: input linear Bathymetric Low features
         # headFeat: input head features
         # footFeat: input foot features
         # distThreshold: a distance threshold used to evaluate the connecting condition
-        
+
         ## connect features that have head to foot distance less than the distance threshold, and intersecting angle less than 45 degree
 
         ### calculate distances between the head and foot features
         itemList = []
 
-        headFeat1 = 'headFeat1'
-        footFeat1 = 'footFeat1'
+        headFeat1 = "headFeat1"
+        footFeat1 = "footFeat1"
         itemList.append(headFeat1)
         itemList.append(footFeat1)
-        
-        arcpy.Copy_management(headFeat,headFeat1)
-        arcpy.Copy_management(footFeat,footFeat1)
-        
-        fieldName = 'featID'
-        self.deleteField(headFeat1,fieldName)
-        self.deleteField(footFeat1,fieldName)
-        
-        fieldName = 'rectangle_Orientation'
-        self.deleteField(headFeat1,fieldName)
-        self.deleteField(footFeat1,fieldName)
-        
-        headFeat2 = 'headFeat2'
-        footFeat2 = 'footFeat2'
+
+        arcpy.Copy_management(headFeat, headFeat1)
+        arcpy.Copy_management(footFeat, footFeat1)
+
+        fieldName = "featID"
+        self.deleteField(headFeat1, fieldName)
+        self.deleteField(footFeat1, fieldName)
+
+        fieldName = "rectangle_Orientation"
+        self.deleteField(headFeat1, fieldName)
+        self.deleteField(footFeat1, fieldName)
+
+        headFeat2 = "headFeat2"
+        footFeat2 = "footFeat2"
         itemList.append(headFeat2)
         itemList.append(footFeat2)
         ## use spatial join to copy the featID and rectangle_Orientation fields to the head and foot features
-        arcpy.SpatialJoin_analysis(headFeat1,inFeat,headFeat2)
-        arcpy.SpatialJoin_analysis(footFeat1,inFeat,footFeat2)
-        # Calculates distances between head and foot features within the input distance threshold (searchRadius) 
-        nearTable = 'head_foot_nearTable'
+        arcpy.SpatialJoin_analysis(headFeat1, inFeat, headFeat2)
+        arcpy.SpatialJoin_analysis(footFeat1, inFeat, footFeat2)
+        # Calculates distances between head and foot features within the input distance threshold (searchRadius)
+        nearTable = "head_foot_nearTable"
         itemList.append(nearTable)
-        location = 'NO_LOCATION'
-        angle = 'NO_ANGLE'
-        closest = 'ALL'
+        location = "NO_LOCATION"
+        angle = "NO_ANGLE"
+        closest = "ALL"
         searchRadius = distThreshold
-        arcpy.GenerateNearTable_analysis(headFeat2,footFeat2,nearTable,search_radius=searchRadius,location=location,angle=angle,closest=closest)
+        arcpy.GenerateNearTable_analysis(
+            headFeat2,
+            footFeat2,
+            nearTable,
+            search_radius=searchRadius,
+            location=location,
+            angle=angle,
+            closest=closest,
+        )
 
         ### get initial list of a pair of features that have head to foot distance less than the input distance threshold
 
@@ -2059,11 +2648,11 @@ class helpers(object):
         footIDList1 = []
         cursor = arcpy.SearchCursor(nearTable)
         for row in cursor:
-            inFID = row.getValue('IN_FID')
-            nearFID = row.getValue('NEAR_FID')            
+            inFID = row.getValue("IN_FID")
+            nearFID = row.getValue("NEAR_FID")
             headIDList1.append(inFID)
             footIDList1.append(nearFID)
-        del cursor,row    
+        del cursor, row
 
         # get  attribute values from the input head features
         headIDAll = []
@@ -2071,52 +2660,51 @@ class helpers(object):
         headOrientationAll = []
         cursor = arcpy.SearchCursor(headFeat2)
         for row in cursor:
-            objectID = row.getValue('OBJECTID')
-            featID = row.getValue('featID')
-            orientation = row.getValue('rectangle_Orientation')
+            objectID = row.getValue("OBJECTID")
+            featID = row.getValue("featID")
+            orientation = row.getValue("rectangle_Orientation")
             headIDAll.append(objectID)
             headFeatIDAll.append(featID)
-            headOrientationAll.append(orientation)            
+            headOrientationAll.append(orientation)
         del cursor, row
-        # get  attribute values from the input foot features        
+        # get  attribute values from the input foot features
         footIDAll = []
         footFeatIDAll = []
         footOrientationAll = []
         cursor = arcpy.SearchCursor(footFeat2)
         for row in cursor:
-            objectID = row.getValue('OBJECTID')
-            featID = row.getValue('featID')
-            orientation = row.getValue('rectangle_Orientation')
+            objectID = row.getValue("OBJECTID")
+            featID = row.getValue("featID")
+            orientation = row.getValue("rectangle_Orientation")
             footIDAll.append(objectID)
             footFeatIDAll.append(featID)
-            footOrientationAll.append(orientation)            
+            footOrientationAll.append(orientation)
         del cursor, row
 
         headFeatIDList1 = []
         footFeatIDList1 = []
         headOrientationList1 = []
         footOrientationList1 = []
-        
-        
+
         for idv in headIDList1:
             featID = headFeatIDAll[headIDAll.index(idv)]
             orientation = headOrientationAll[headIDAll.index(idv)]
             headFeatIDList1.append(featID)
             headOrientationList1.append(orientation)
-            
+
         for idv in footIDList1:
             featID = footFeatIDAll[footIDAll.index(idv)]
             orientation = footOrientationAll[footIDAll.index(idv)]
             footFeatIDList1.append(featID)
-            footOrientationList1.append(orientation)  
+            footOrientationList1.append(orientation)
 
         ### calculate intersecting angles for the feature pairs
         angleList = []
         i = 0
-        while i < len(headOrientationList1):           
+        while i < len(headOrientationList1):
             orientation1 = headOrientationList1[i]
             orientation2 = footOrientationList1[i]
-            orientation_diff = abs(orientation1-orientation2)
+            orientation_diff = abs(orientation1 - orientation2)
             angleList.append(orientation_diff)
             i += 1
 
@@ -2125,18 +2713,20 @@ class helpers(object):
         headFeatIDList2 = []
         footFeatIDList2 = []
         i = 0
-        while i < len(angleList):        
+        while i < len(angleList):
             angle = angleList[i]
             headFeatID = headFeatIDList1[i]
             footFeatID = footFeatIDList1[i]
             if (angle < 45) or (angle > 135):
-                idListList1.append([headFeatID,footFeatID])
+                idListList1.append([headFeatID, footFeatID])
                 headFeatIDList2.append(headFeatID)
                 footFeatIDList2.append(footFeatID)
             i += 1
 
         ### merge feature pairs if they share a common feature
-        idListList2 = [] #each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
+        idListList2 = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
         i = 0
         headIDArray = np.asarray(headFeatIDList2)
         footIDArray = np.asarray(footFeatIDList2)
@@ -2146,16 +2736,20 @@ class helpers(object):
             headID = headFeatIDList2[i]
             footID = footFeatIDList2[i]
 
-            if headFeatIDList2.count(headID) > 1: # if multiple pairs share the same headID (e.g. [1,2],[1,3]), select the feature pair with the minimum intersecting angle
+            if (
+                headFeatIDList2.count(headID) > 1
+            ):  # if multiple pairs share the same headID (e.g. [1,2],[1,3]), select the feature pair with the minimum intersecting angle
                 indices = np.where(headIDArray == headID)[0]
                 angleListTemp = []
                 for index in indices:
                     angle = angleList[index]
                     angleListTemp.append(angle)
                 ids1 = idListList1[angleList.index(min(angleListTemp))]
-                if ids1 not in idListList2:            
-                    idListList2.append(ids1)  
-            elif footFeatIDList2.count(footID) > 1: # if multiple pairs share the same footID (e.g. [2,1],[3,1]), select the feature pair with the minimum intersecting angle
+                if ids1 not in idListList2:
+                    idListList2.append(ids1)
+            elif (
+                footFeatIDList2.count(footID) > 1
+            ):  # if multiple pairs share the same footID (e.g. [2,1],[3,1]), select the feature pair with the minimum intersecting angle
                 indices = np.where(footIDArray == footID)[0]
                 angleListTemp = []
                 for index in indices:
@@ -2164,21 +2758,25 @@ class helpers(object):
                 ids1 = idListList1[angleList.index(min(angleListTemp))]
                 if ids1 not in idListList2:
                     idListList2.append(ids1)
-            elif headID in footFeatIDList2: # if two pairs (e.g., [2,1],[5,2]), indicates the three features are connected, so add both pairs
+            elif (
+                headID in footFeatIDList2
+            ):  # if two pairs (e.g., [2,1],[5,2]), indicates the three features are connected, so add both pairs
                 ids1 = idListList1[footFeatIDList2.index(headID)]
                 tempList.append(ids)
                 tempList.append(ids1)
                 tempList = self.getUnique(tempList)
                 if tempList not in idListList2:
                     idListList2.append(tempList)
-            elif footID in headFeatIDList2: # if two pairs (e.g., [1,2],[2,5]), indicates the three features are connected, so add both pairs
+            elif (
+                footID in headFeatIDList2
+            ):  # if two pairs (e.g., [1,2],[2,5]), indicates the three features are connected, so add both pairs
                 ids1 = idListList1[headFeatIDList2.index(footID)]
                 tempList.append(ids)
                 tempList.append(ids1)
                 tempList = self.getUnique(tempList)
                 if tempList not in idListList2:
                     idListList2.append(tempList)
-            else: # otherwise, just keep the pair
+            else:  # otherwise, just keep the pair
                 idListList2.append(ids)
             i += 1
 
@@ -2187,90 +2785,99 @@ class helpers(object):
         for row in cursor:
             featID = row.getValue("featID")
             featIDList.append(featID)
-        del cursor,row    
-
+        del cursor, row
 
         ### assign a same featID to features to be connected
         featIDNewList = featIDList.copy()
-        for tempList in idListList2:    
+        for tempList in idListList2:
             indexList = []
             featureIDList = []
             for idv in tempList:
                 index = featIDList.index(idv)
-                featureID = featIDList[index]        
+                featureID = featIDList[index]
                 indexList.append(index)
                 featureIDList.append(featureID)
             for index in indexList:
                 featIDNewList[index] = featureIDList[0]
 
         return featIDNewList
-        
+
     # This function gets a count of feature sharing by borders and merges input features sharing points
-    def mergeFeatures(self,inFeat,dissolveFeat,dissolveFeat1,dissolveFeat2):
+    def mergeFeatures(self, inFeat, dissolveFeat, dissolveFeat1, dissolveFeat2):
         # inFeat: input features
         # dissolveFeat: input features after merging features sharing borders and points
         # dissolveFeat1: input features after merging only features sharing borders
         # dissolvedFeat2: output features after merging only features sharing points
-        
+
         itemList = []
-        
+
         # select individual input features that share points and those stand-alone features
-        tempLayer = 'tempLyr'
-        arcpy.MakeFeatureLayer_management(inFeat, tempLayer) 
-        arcpy.SelectLayerByLocation_management(tempLayer, 'ARE_IDENTICAL_TO', dissolveFeat1)
-        selectFeat1 = 'selectFeat1'
+        tempLayer = "tempLyr"
+        arcpy.MakeFeatureLayer_management(inFeat, tempLayer)
+        arcpy.SelectLayerByLocation_management(
+            tempLayer, "ARE_IDENTICAL_TO", dissolveFeat1
+        )
+        selectFeat1 = "selectFeat1"
         itemList.append(selectFeat1)
         arcpy.CopyFeatures_management(tempLayer, selectFeat1)
-        arcpy.AddMessage(selectFeat1 + ' done')
+        arcpy.AddMessage(selectFeat1 + " done")
         # select dissolved features sharing points and stand-alone features
-        tempLayer = 'tempLyr'
-        arcpy.MakeFeatureLayer_management(dissolveFeat, tempLayer) 
-        arcpy.SelectLayerByLocation_management(tempLayer, 'intersect', selectFeat1)
-        selectFeat2 = 'selectFeat2'
+        tempLayer = "tempLyr"
+        arcpy.MakeFeatureLayer_management(dissolveFeat, tempLayer)
+        arcpy.SelectLayerByLocation_management(tempLayer, "intersect", selectFeat1)
+        selectFeat2 = "selectFeat2"
         itemList.append(selectFeat2)
         arcpy.CopyFeatures_management(tempLayer, selectFeat2)
-        arcpy.AddMessage(selectFeat2 + ' done')
+        arcpy.AddMessage(selectFeat2 + " done")
         # select individual input features sharing borders
-        tempLayer = 'tempLyr'
-        arcpy.MakeFeatureLayer_management(inFeat, tempLayer) 
-        arcpy.SelectLayerByLocation_management(tempLayer, 'ARE_IDENTICAL_TO', dissolveFeat1, 
-                                               invert_spatial_relationship = 'INVERT')
-        selectFeat3 = 'selectFeat3'
+        tempLayer = "tempLyr"
+        arcpy.MakeFeatureLayer_management(inFeat, tempLayer)
+        arcpy.SelectLayerByLocation_management(
+            tempLayer,
+            "ARE_IDENTICAL_TO",
+            dissolveFeat1,
+            invert_spatial_relationship="INVERT",
+        )
+        selectFeat3 = "selectFeat3"
         itemList.append(selectFeat3)
         arcpy.CopyFeatures_management(tempLayer, selectFeat3)
-        arcpy.AddMessage(selectFeat3 + ' done')
-        
+        arcpy.AddMessage(selectFeat3 + " done")
+
         count = int(arcpy.GetCount_management(selectFeat3).getOutput(0))
         # erase features that share borders from selected dissolved features sharing points and stand-alone features
-        erasedFeat = 'easedFeat'
+        erasedFeat = "easedFeat"
         itemList.append(erasedFeat)
-        arcpy.Erase_analysis(selectFeat2,selectFeat3,erasedFeat)
+        arcpy.Erase_analysis(selectFeat2, selectFeat3, erasedFeat)
 
         # select individual input features sharing both borders and points
-        tempLayer = 'tempLyr'
-        arcpy.MakeFeatureLayer_management(selectFeat3, tempLayer) 
-        arcpy.SelectLayerByLocation_management(tempLayer, 'BOUNDARY_TOUCHES', erasedFeat, 
-                                               invert_spatial_relationship = 'INVERT')
-        selectFeat3_1 = 'selectFeat3_1'
+        tempLayer = "tempLyr"
+        arcpy.MakeFeatureLayer_management(selectFeat3, tempLayer)
+        arcpy.SelectLayerByLocation_management(
+            tempLayer,
+            "BOUNDARY_TOUCHES",
+            erasedFeat,
+            invert_spatial_relationship="INVERT",
+        )
+        selectFeat3_1 = "selectFeat3_1"
         itemList.append(selectFeat3_1)
         arcpy.CopyFeatures_management(tempLayer, selectFeat3_1)
-        arcpy.AddMessage(selectFeat3_1 + ' done')        
+        arcpy.AddMessage(selectFeat3_1 + " done")
 
         # erase features that share borders from dissolved features sharing points and stand-alone features
-        erasedFeat1 = 'easedFeat1'
+        erasedFeat1 = "easedFeat1"
         itemList.append(erasedFeat1)
-        arcpy.Erase_analysis(dissolveFeat,selectFeat3_1,erasedFeat1)
-        
+        arcpy.Erase_analysis(dissolveFeat, selectFeat3_1, erasedFeat1)
+
         # merge features in the erased and fourth sets
         # which results in output features after merging features sharing points
-        inFeats = [erasedFeat1,selectFeat3_1]
-        arcpy.Merge_management(inFeats,dissolveFeat2)
+        inFeats = [erasedFeat1, selectFeat3_1]
+        arcpy.Merge_management(inFeats, dissolveFeat2)
         itemList.append(tempLayer)
-##        self.deleteDataItems(itemList)
+        ##        self.deleteDataItems(itemList)
         return count
 
     # This function adds and calculates a double field from a joined featureclass
-    def addField(self,inFeat,joinFeat,fieldName,inID,joinID,expression):
+    def addField(self, inFeat, joinFeat, fieldName, inID, joinID, expression):
         # inFeat: input featureclass (or table)
         # joinFeat: feature (or table) to be joined with the inFeat
         # fieldName: the field in the inFeat to be calculated from the joinFeat
@@ -2288,7 +2895,9 @@ class helpers(object):
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
 
         layerName = "tempLyr"
         arcpy.MakeFeatureLayer_management(inFeat, layerName)
@@ -2303,7 +2912,7 @@ class helpers(object):
         return
 
     # This function adds and calculates a long field from a joined featureclass
-    def addLongField(self,inFeat,joinFeat,fieldName,inID,joinID,expression):
+    def addLongField(self, inFeat, joinFeat, fieldName, inID, joinID, expression):
         # inFeat: input featureclass (or table)
         # joinFeat: feature (or table) to be joined with the inFeat
         # fieldName: the field in the inFeat to be calculated from the joinFeat
@@ -2320,7 +2929,7 @@ class helpers(object):
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(inFeat, fieldName, fieldType, fieldPrecision)
 
         layerName = "tempLyr"
         arcpy.MakeFeatureLayer_management(inFeat, layerName)
@@ -2335,7 +2944,7 @@ class helpers(object):
         return
 
     # This function adds and calculates a long field from a joined featureclass
-    def addTextField(self,inFeat,joinFeat,fieldName,inID,joinID,expression):
+    def addTextField(self, inFeat, joinFeat, fieldName, inID, joinID, expression):
         # inFeat: input featureclass (or table)
         # joinFeat: feature (or table) to be joined with the inFeat
         # fieldName: the field in the inFeat to be calculated from the joinFeat
@@ -2343,7 +2952,7 @@ class helpers(object):
         # joinID: unique id field in the joinFeat that matches the inID
         # expression: expression text used to calculate the field
 
-        fieldType = 'text'
+        fieldType = "text"
         fieldLength = 10
 
         fields = arcpy.ListFields(inFeat)
@@ -2352,7 +2961,7 @@ class helpers(object):
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldLength)
+            arcpy.AddField_management(inFeat, fieldName, fieldType, fieldLength)
 
         layerName = "tempLyr"
         arcpy.MakeFeatureLayer_management(inFeat, layerName)
@@ -2367,11 +2976,21 @@ class helpers(object):
         return
 
     # This function lists duplicated elements
-    def RiteshKumar(self,inList):
-        return list(set([x for x in inList if inList.count(x) > 1]))
+    def RiteshKumar(self, inList):
+        return list({x for x in inList if inList.count(x) > 1})
 
     # This function selects two subsets from the input link features
-    def doLinks1(self,inLinkFeat,outLinkFeat1,outLinkFeat2,distThreshold,angleThreshold,distWeight,angleWeight,linkDirection):
+    def doLinks1(
+        self,
+        inLinkFeat,
+        outLinkFeat1,
+        outLinkFeat2,
+        distThreshold,
+        angleThreshold,
+        distWeight,
+        angleWeight,
+        linkDirection,
+    ):
         # inLinkFeat: input link featureclass obtained from the GenerateOriginDestinationLinks ArcGIS tool
         # outLinkFeat1: output link featureclass after the first selection
         # outLinkFeat2: output link featureclass after the second selection
@@ -2380,36 +2999,42 @@ class helpers(object):
         # distWeight: weight assigned to distance, used to calculate a combined metric from the distance and angle metrics (used in getIndex())
         # angleWeight: weight assigned to angle, used to calculate a combined metric from the distance and angle metrics (used in getIndex())
         # linkDirection: a text string indicating the link direction to be processed
-        
+
         # add and calculate a number of fields
-        
+
         fields = arcpy.ListFields(inLinkFeat)
         fieldNames = [f.name for f in fields]
-        
+
         fieldType = "LONG"
         fieldPrecision = 15
-        fieldName = 'tempID'
+        fieldName = "tempID"
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(inLinkFeat, fieldName, fieldType, fieldPrecision)
         expression = "!OBJECTID!"
         arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3")
 
-        if linkDirection != "FH":        
+        if linkDirection != "FH":
             fieldType = "DOUBLE"
             fieldPrecision = 15
             fieldScale = 6
-            fieldName = 'idRatio'
+            fieldName = "idRatio"
             if fieldName not in fieldNames:
-                arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+                arcpy.AddField_management(
+                    inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+                )
             expression = "!ORIG_FID! / !DEST_FID!"
-            arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3")
+            arcpy.CalculateField_management(
+                inLinkFeat, fieldName, expression, "PYTHON_9.3"
+            )
 
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
-        fieldName = 'angle_diff'
+        fieldName = "angle_diff"
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
         expression = "getAngle(abs(!angle1! - !angle2!))"
 
         codeblock = """
@@ -2418,33 +3043,43 @@ def getAngle(inAngle):
         return 180 - inAngle
     else:
         return inAngle"""
-        
-        arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3", codeblock)
+
+        arcpy.CalculateField_management(
+            inLinkFeat, fieldName, expression, "PYTHON_9.3", codeblock
+        )
 
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
-        fieldName = 'X_diff' # whether the origin feature is to the east or west of the destination feature
+        fieldName = "X_diff"  # whether the origin feature is to the east or west of the destination feature
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
         expression = "!ORIG_X! - !DEST_X!"
         arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3")
-        
+
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
-        fieldName = 'Y_diff' # whether the origin feature is to the south or north of the destination feature
+        fieldName = "Y_diff"  # whether the origin feature is to the south or north of the destination feature
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
         expression = "!ORIG_Y! - !DEST_Y!"
         arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3")
 
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
-        fieldName = 'link_angle' # orientation of the links in relative to north (0-180)
+        fieldName = (
+            "link_angle"  # orientation of the links in relative to north (0-180)
+        )
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
         expression = "getAngle(!X_diff!,!Y_diff!)"
         codeblock = """
 def getAngle(x,y):
@@ -2457,15 +3092,19 @@ def getAngle(x,y):
         return 180 + inAngle
     else:
         return inAngle"""
-        
-        arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3",codeblock)
+
+        arcpy.CalculateField_management(
+            inLinkFeat, fieldName, expression, "PYTHON_9.3", codeblock
+        )
 
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
-        fieldName = 'link_angle_diff'
+        fieldName = "link_angle_diff"
         if fieldName not in fieldNames:
-            arcpy.AddField_management(inLinkFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inLinkFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
         expression = "(getAngle(abs(!angle1! - !link_angle!)) + getAngle(abs(!angle2! - !link_angle!))) / 2"
         codeblock = """
 def getAngle(inAngle):
@@ -2473,24 +3112,28 @@ def getAngle(inAngle):
         return 180 - inAngle
     else:
         return inAngle"""
-        
-        arcpy.CalculateField_management(inLinkFeat, fieldName, expression, "PYTHON_9.3",codeblock)
-        
+
+        arcpy.CalculateField_management(
+            inLinkFeat, fieldName, expression, "PYTHON_9.3", codeblock
+        )
+
         arcpy.AddMessage("fields added and calculated")
-        
+
         # select a subset, removing self-links (e.g., from S point of a feature to the N point of the same feature, indicated by 'temp == 1')
         # removing links with angle_diff larger than the angle threshold
         linkTempFeat = "linkTempFeat"
         if linkDirection == "FH":
-            whereClause = 'angle_diff < ' + str(angleThreshold)
+            whereClause = "angle_diff < " + str(angleThreshold)
         else:
-            whereClause = '(idRatio <> 1) And (angle_diff < ' + str(angleThreshold) + ')'        
-        arcpy.Select_analysis(inLinkFeat,linkTempFeat,whereClause)
-        
+            whereClause = (
+                "(idRatio <> 1) And (angle_diff < " + str(angleThreshold) + ")"
+            )
+        arcpy.Select_analysis(inLinkFeat, linkTempFeat, whereClause)
+
         # further select from the above subset based on the speficied criteria for the link direction
         inFeatCount = int(arcpy.GetCount_management(linkTempFeat).getOutput(0))
         linkTempFeat1 = "linkTempFeat1"
-        # inFeatCount = 0 indicates that there is not any feature satsifying the criterion specified (angle_diff < angleThreshold) for the link direction. 
+        # inFeatCount = 0 indicates that there is not any feature satsifying the criterion specified (angle_diff < angleThreshold) for the link direction.
         if inFeatCount > 0:
             # These four threshold values are hard-coded here, for the time being.
             # They could be changed if deemed not suitable.
@@ -2503,73 +3146,300 @@ def getAngle(inAngle):
             if linkDirection == "SN":
                 # two "Or" conditions: 1. the northern feature is at some distance north of the southern feature (Y_diff attribute) and the two features have similar orientations (within a threshold)(link_angle_diff attribute); or
                 # 2. the northern and southern features are close together in both the north-south direction (Y_diff attribute) and link direction (LINK_DIST attribute)
-                whereClause = '((Y_diff >' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + '))' + ' Or ((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ') And (LINK_DIST < ' + str(dT) + '))'
+                whereClause = (
+                    "((Y_diff >"
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + "))"
+                    + " Or ((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ") And (LINK_DIST < "
+                    + str(dT)
+                    + "))"
+                )
             elif linkDirection == "NS":
                 # two "Or" conditions: 1. the southern feature is at some distance south of the northern feature (Y_diff attribute) and the two features have similar orientations (within a threshold)(link_angle_diff attribute); or
                 # 2. the northern and southern features are close together in both the north-south direction (Y_diff attribute) and link direction (LINK_DIST attribute)
-                whereClause = '((Y_diff <' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + '))' + ' Or ((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ') And (LINK_DIST < ' + str(dT) + '))'
+                whereClause = (
+                    "((Y_diff <"
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + "))"
+                    + " Or ((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ") And (LINK_DIST < "
+                    + str(dT)
+                    + "))"
+                )
             elif linkDirection == "WE":
                 # two "Or" conditions: 1. the western feature is at some distance west of the eastern feature (X_diff attribute) and the two features have similar orientations (within a threshold); or
                 # 2. the western and eastern features are close together in both the east-west direction (X_diff attribute) and link direction
-                whereClause = '((X_diff >' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + '))' + ' Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + ') And (LINK_DIST < ' + str(dT) + '))'
+                whereClause = (
+                    "((X_diff >"
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + "))"
+                    + " Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + ") And (LINK_DIST < "
+                    + str(dT)
+                    + "))"
+                )
             elif linkDirection == "EW":
                 # two "Or" conditions: 1. the eastern feature is at some distance east of the western feature (X_diff attribute) and the two features have similar orientations (within a threshold); or
                 # 2. the western and eastern features are close together in both the east-west direction (X_diff attribute) and link direction
-                whereClause = '((X_diff <' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + '))' + ' Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + ') And (LINK_DIST < ' + str(dT) + '))'
+                whereClause = (
+                    "((X_diff <"
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + "))"
+                    + " Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + ") And (LINK_DIST < "
+                    + str(dT)
+                    + "))"
+                )
             elif linkDirection == "EN":
                 # several "And" conditons: 1. the orientation of the eastern feature (angle1 attribute) must be 90-135; and 2. the orientation of the northern feature (anlge2 attribute) must be 135-180; and
                 # 3. a complex "Or" conditon: a) the eastern feature and the northern feature must be at some distant away from each other in both N-S (Y_diff attribute) and E-W (X_diff attribute) directions
                 # and the two features have similar orientations (within a threshold); or
-                # b) the eastern feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle1 >= 90) And (angle1 <= 135) And (angle2 >= 135) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff > ' + str(distT1) + ') And (X_diff < ' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the eastern feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle1 >= 90) And (angle1 <= 135) And (angle2 >= 135) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff > "
+                    + str(distT1)
+                    + ") And (X_diff < "
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "NE":
                 # several "And" conditons: 1. the orientation of the northern feature (angle1 attribute) must be 135-180; and 2. the orientation of the eastern feature (anlge1 attribute) must be 135-180; and
                 # 3. a complex "Or" conditon: a) the northern feature and the eastern feature must be at some distant away from each other in both N-S (Y_diff attribute) and E-W (X_diff attribute) directions
                 # and the two features have similar orientations (within a threshold); or
-                # b) the eastern feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle2 >= 90) And (angle2 <= 135) And (angle1 >= 135) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff < ' + str(distT2) + ') And (X_diff > ' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the eastern feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle2 >= 90) And (angle2 <= 135) And (angle1 >= 135) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff < "
+                    + str(distT2)
+                    + ") And (X_diff > "
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "SW":
                 # several "And" conditons: 1. the orientation of the southern feature must be 135-180; and 2. the orientation of the western feature must be 90-135; and
                 # 3. a complex "Or" conditon: a) the southern feature and the western feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the southern feature and the western feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle1 >= 135) And (angle2 >= 90) And (angle2 <= 135) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff > ' + str(distT1) + ') And (X_diff < ' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the southern feature and the western feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle1 >= 135) And (angle2 >= 90) And (angle2 <= 135) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff > "
+                    + str(distT1)
+                    + ") And (X_diff < "
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "WS":
                 # several "And" conditons: 1. the orientation of the western feature must be 90-135; and 2. the orientation of the southern feature must be 135-180; and
                 # 3. a complex "Or" conditon: a) the western feature and the southern feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the southern feature and the western feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle2 >= 135) And (angle1 >= 90) And (angle1 <= 135) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff < ' + str(distT2) + ') And (X_diff > ' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the southern feature and the western feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle2 >= 135) And (angle1 >= 90) And (angle1 <= 135) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff < "
+                    + str(distT2)
+                    + ") And (X_diff > "
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "SE":
                 # several "And" conditons: 1. the orientation of the southern feature must be 0-45; and 2. the orientation of the eastern feature must be 45-90; and
                 # 3. a complex "Or" conditon: a) the southern feature and the eastern feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the southern feature and the eastern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle1 <= 45) And (angle2 >= 45) And (angle2 <= 90) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff > ' + str(distT1) + ') And (X_diff > ' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the southern feature and the eastern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle1 <= 45) And (angle2 >= 45) And (angle2 <= 90) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff > "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "ES":
                 # several "And" conditons: 1. the orientation of the eastern feature must be 45-90; and 2. the orientation of the eastern feature must be 0-45; and
                 # 3. a complex "Or" conditon: a) the southern feature and the eastern feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the southern feature and the eastern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle2 <= 45) And (angle1 >= 45) And (angle1 <= 90) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff < ' + str(distT2) + ') And (X_diff < ' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the southern feature and the eastern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle2 <= 45) And (angle1 >= 45) And (angle1 <= 90) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff < "
+                    + str(distT2)
+                    + ") And (X_diff < "
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "WN":
                 # several "And" conditons: 1. the orientation of the western feature must be 45-90; and 2. the orientation of the northern feature must be 0-45; and
                 # 3. a complex "Or" conditon: a) the western feature and the northern feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the western feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle1 >= 45) And (angle1 <= 90) And (angle2 <= 45) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff > ' + str(distT1) + ') And (X_diff > ' + str(distT1) + ') And (link_angle_diff < ' + str(laT) + ')))'
+                # b) the western feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle1 >= 45) And (angle1 <= 90) And (angle2 <= 45) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff > "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT1)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
             elif linkDirection == "NW":
                 # several "And" conditons: 1. the orientation of the northern feature must be 0-45; and 2. the orientation of the western feature must be 45-90; and
                 # 3. a complex "Or" conditon: a) the northern feature and the western feature must be at some distant away from each other in both N-S and E-W directions and the two features have similar orientations (within a threshold); or
-                # b) the western feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction 
-                whereClause = '(angle2 >= 45) And (angle2 <= 90) And (angle1 <= 45) And ' + '(((((Y_diff < ' + str(distT1) + ') And (Y_diff > ' + str(distT2) + ')) Or ((X_diff < ' + str(distT1) + ') And (X_diff > ' + str(distT2) + '))) And (link_dist < ' + str(dT) + ')) Or ((Y_diff < ' + str(distT2) + ') And (X_diff < ' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + ')))'
-            elif linkDirection == "FH": # connect foot to head features, not longer in use
+                # b) the western feature and the northern feature must be close in link direction and also close in either the N-S or E-W direction
+                whereClause = (
+                    "(angle2 >= 45) And (angle2 <= 90) And (angle1 <= 45) And "
+                    + "(((((Y_diff < "
+                    + str(distT1)
+                    + ") And (Y_diff > "
+                    + str(distT2)
+                    + ")) Or ((X_diff < "
+                    + str(distT1)
+                    + ") And (X_diff > "
+                    + str(distT2)
+                    + "))) And (link_dist < "
+                    + str(dT)
+                    + ")) Or ((Y_diff < "
+                    + str(distT2)
+                    + ") And (X_diff < "
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + ")))"
+                )
+            elif (
+                linkDirection == "FH"
+            ):  # connect foot to head features, not longer in use
                 # two "Or" conditions: 1. the two features are close together in both north-south and east-west directions (X_diff and Y_diff attributes) and link direction (LINK_DIST attribute); or
                 # 2. the two features are not close in either north-south (Y_diff attribute) or east-west directions (X_diff attribute) and they have similar orientations (within a threshold) (link_angle_diff attribute).
-                whereClause = '((X_diff <= ' + str(distT1) + ' And X_diff >= ' + str(distT2) + ' And Y_diff <= ' + str(distT1) + ' And Y_diff >= ' + str(distT2) + ') AND (LINK_DIST < ' + str(dT) + ')) OR ((X_diff > ' + str(distT1) + ' Or X_diff < ' + str(distT2) + ' Or Y_diff > ' + str(distT2) + ' Or Y_diff < ' + str(distT2) + ') And (link_angle_diff < ' + str(laT) + '))'
+                whereClause = (
+                    "((X_diff <= "
+                    + str(distT1)
+                    + " And X_diff >= "
+                    + str(distT2)
+                    + " And Y_diff <= "
+                    + str(distT1)
+                    + " And Y_diff >= "
+                    + str(distT2)
+                    + ") AND (LINK_DIST < "
+                    + str(dT)
+                    + ")) OR ((X_diff > "
+                    + str(distT1)
+                    + " Or X_diff < "
+                    + str(distT2)
+                    + " Or Y_diff > "
+                    + str(distT2)
+                    + " Or Y_diff < "
+                    + str(distT2)
+                    + ") And (link_angle_diff < "
+                    + str(laT)
+                    + "))"
+                )
 
-            
-            arcpy.Select_analysis(linkTempFeat,linkTempFeat1,whereClause)
+            arcpy.Select_analysis(linkTempFeat, linkTempFeat1, whereClause)
         else:
-            arcpy.Copy_management(linkTempFeat,linkTempFeat1)
-            
+            arcpy.Copy_management(linkTempFeat, linkTempFeat1)
+
         arcpy.AddMessage("first selection done")
-        
+
         # further selection
         inFeatCount = int(arcpy.GetCount_management(linkTempFeat1).getOutput(0))
         if inFeatCount > 0:
@@ -2583,11 +3453,11 @@ def getAngle(inAngle):
             distList = []
             idListList = []
             for row in cursor:
-                tempID = row.getValue('tempID')
-                originID = row.getValue('ORIG_FID')
-                destID = row.getValue('DEST_FID')
-                dist = row.getValue('LINK_DIST')
-                idList = [originID,destID]
+                tempID = row.getValue("tempID")
+                originID = row.getValue("ORIG_FID")
+                destID = row.getValue("DEST_FID")
+                dist = row.getValue("LINK_DIST")
+                idList = [originID, destID]
                 tempIDList.append(tempID)
                 originIDList.append(originID)
                 destIDList.append(destID)
@@ -2598,14 +3468,18 @@ def getAngle(inAngle):
             leng1 = len(idListList)
             idListList1 = self.getUnique2D(idListList)
             leng2 = len(idListList1)
-            if leng1 > leng2: # Mid points and Most distant points option (ie. the combined option) selected
+            if (
+                leng1 > leng2
+            ):  # Mid points and Most distant points option (ie. the combined option) selected
                 i = 0
                 tempIDList1 = []
                 idsArray = np.asarray(idListList)
-                while i < leng2: # loop through each unique [originID,destID]
+                while i < leng2:  # loop through each unique [originID,destID]
                     idList = idListList1[i]
-                    indices = np.where((idsArray[:,0] == idList[0])&(idsArray[:,1] == idList[1]))[0]
-                    indexList = indices.tolist()                
+                    indices = np.where(
+                        (idsArray[:, 0] == idList[0]) & (idsArray[:, 1] == idList[1])
+                    )[0]
+                    indexList = indices.tolist()
                     distListTemp = []
                     for index in indices:
                         dist = distList[index]
@@ -2615,24 +3489,24 @@ def getAngle(inAngle):
                     tempIDList1.append(tempIDList[j])
                     i += 1
                 # select subset
-                text = '('
+                text = "("
                 for j in tempIDList1:
-                    text = text + str(j) + ','
-                text = text[0:-1] + ')'
-                whereClause = 'tempID IN ' + text
-                arcpy.Select_analysis(linkTempFeat1,outLinkFeat1,whereClause)
-                                  
-            else: # one of the other two options selected
-                arcpy.Copy_management(linkTempFeat1,outLinkFeat1)
+                    text = text + str(j) + ","
+                text = text[0:-1] + ")"
+                whereClause = "tempID IN " + text
+                arcpy.Select_analysis(linkTempFeat1, outLinkFeat1, whereClause)
+
+            else:  # one of the other two options selected
+                arcpy.Copy_management(linkTempFeat1, outLinkFeat1)
         else:
-            arcpy.Copy_management(linkTempFeat1,outLinkFeat1)
+            arcpy.Copy_management(linkTempFeat1, outLinkFeat1)
         arcpy.AddMessage("second selection done")
 
         # further selection
         inFeatCount = int(arcpy.GetCount_management(outLinkFeat1).getOutput(0))
-        if inFeatCount > 0:  
+        if inFeatCount > 0:
             # doing the third selection
-            # if multiple records have the same ORIG_FID or DEST_ID (eg., between [1,3] and [1,4] or between [1,10] and [2,10]), 
+            # if multiple records have the same ORIG_FID or DEST_ID (eg., between [1,3] and [1,4] or between [1,10] and [2,10]),
             # just select the one with min combination of distance and angle_diff
             cursor = arcpy.SearchCursor(outLinkFeat1)
             tempIDList = []
@@ -2641,11 +3515,11 @@ def getAngle(inAngle):
             distList = []
             angleList = []
             for row in cursor:
-                tempID = row.getValue('tempID')
-                originID = row.getValue('ORIG_FID')
-                destID = row.getValue('DEST_FID')
-                dist = row.getValue('LINK_DIST')
-                angle = row.getValue('angle_diff')
+                tempID = row.getValue("tempID")
+                originID = row.getValue("ORIG_FID")
+                destID = row.getValue("DEST_FID")
+                dist = row.getValue("LINK_DIST")
+                angle = row.getValue("angle_diff")
                 tempIDList.append(tempID)
                 originIDList.append(originID)
                 destIDList.append(destID)
@@ -2655,51 +3529,70 @@ def getAngle(inAngle):
             inIDListList = []
             i = 0
             while i < len(originIDList):
-                te = [originIDList[i],destIDList[i]]
+                te = [originIDList[i], destIDList[i]]
                 inIDListList.append(te)
                 i += 1
-            # call the doLists() function to conduct the selection    
-            list1,list2,list3,list4,list5 = self.doLists(originIDList,destIDList,inIDListList,distList,angleList,distThreshold,angleThreshold,distWeight,angleWeight)
+            # call the doLists() function to conduct the selection
+            list1, list2, list3, list4, list5 = self.doLists(
+                originIDList,
+                destIDList,
+                inIDListList,
+                distList,
+                angleList,
+                distThreshold,
+                angleThreshold,
+                distWeight,
+                angleWeight,
+            )
             tempIDList1 = []
             # update the list
             for l in list3:
                 i = inIDListList.index(l)
                 tempIDList1.append(tempIDList[i])
-                
+
             # select subset
-            text = '('
+            text = "("
             for i in tempIDList1:
-                text = text + str(i) + ','
-            text = text[0:-1] + ')'
-            whereClause = 'tempID IN ' + text
-            arcpy.Select_analysis(outLinkFeat1,outLinkFeat2,whereClause)
+                text = text + str(i) + ","
+            text = text[0:-1] + ")"
+            whereClause = "tempID IN " + text
+            arcpy.Select_analysis(outLinkFeat1, outLinkFeat2, whereClause)
         else:
-            arcpy.Copy_management(outLinkFeat1,outLinkFeat2)
+            arcpy.Copy_management(outLinkFeat1, outLinkFeat2)
         arcpy.AddMessage("third selection done")
-        
+
         arcpy.Delete_management(linkTempFeat)
         arcpy.Delete_management(linkTempFeat1)
 
     # This function gets the indices based on distance and angle criteria
-    def getIndex(self,indexList,distList,angleList,distThreshold,angleThreshold,distWeight,angleWeight):
+    def getIndex(
+        self,
+        indexList,
+        distList,
+        angleList,
+        distThreshold,
+        angleThreshold,
+        distWeight,
+        angleWeight,
+    ):
         # indexList: initial index list
         # distList: initial distance list
         # angleList: initial angle list
         # distThreshold: threshold value for distance between two nearby features
         # angleThreshold: threshold value for the intersecting angle between two nearby features
-        # distWeight: weight assigned to distance, used to calculate a combination metric from distance and angle 
-        # angleWeight: weight assigned to angle, used to calculate a combination metric from distance and angle 
+        # distWeight: weight assigned to distance, used to calculate a combination metric from distance and angle
+        # angleWeight: weight assigned to angle, used to calculate a combination metric from distance and angle
 
         distThreshold = float(distThreshold)
         angleThreshold = float(angleThreshold)
         distWeight = float(distWeight)
         angleWeight = float(angleWeight)
 
-        cL = [] # elements in list cL are calculated from distance and angle
+        cL = []  # elements in list cL are calculated from distance and angle
         i = 0
         while i < len(distList):
-            d = distList[i]/distThreshold
-            a = angleList[i]/angleThreshold
+            d = distList[i] / distThreshold
+            a = angleList[i] / angleThreshold
             # calculate weighted average from distWeight and angleWeight
             c = (d * distWeight + a * angleWeight) / (distWeight + angleWeight)
             cL.append(c)
@@ -2717,7 +3610,18 @@ def getAngle(inAngle):
             return indexList[indices[0]]
 
     # This function updates ids list when multiple elements share "from" or "to" points
-    def doLists(self,featID1List,featID2List,inIDListList,distList,angleList,distThreshold,angleThreshold,distWeight,angleWeight):
+    def doLists(
+        self,
+        featID1List,
+        featID2List,
+        inIDListList,
+        distList,
+        angleList,
+        distThreshold,
+        angleThreshold,
+        distWeight,
+        angleWeight,
+    ):
         # featID1List: featIDs of the "from" points
         # featID2List: featIDs of the "to" points
         # inIDListList: list of [featID1,featID2]
@@ -2727,12 +3631,11 @@ def getAngle(inAngle):
         # angleThreshold: threshold value for the intersecting angle between two nearby features
         # distWeight: weight assigned to distance, used to calculate a combination metric from distance and angle (used in getIndex())
         # angleWeight: weight assigned to angle, used to calculate a combination metric from distance and angle (used in getIndex())
-        
-        
+
         # first round, doing features sharing featID1 (featID of the from point)
-        # each element in outIDListList1 contains ids of connected features 
+        # each element in outIDListList1 contains ids of connected features
         # e.g. [[1, 2, 3, 5], [4, 9], [6, 13]]
-        outIDListList1 = [] 
+        outIDListList1 = []
         featID1List1 = []
         featID2List1 = []
         distList1 = []
@@ -2740,17 +3643,17 @@ def getAngle(inAngle):
         i = 0
         featID1Array = np.asarray(featID1List)
         featID2Array = np.asarray(featID2List)
-        while i < len(inIDListList): # loop through each [featID1,featID2]
+        while i < len(inIDListList):  # loop through each [featID1,featID2]
             tempList = []
             ids = inIDListList[i]
             featID1 = featID1List[i]
             featID2 = featID2List[i]
             dist = distList[i]
             angle = angleList[i]
-            # if multiple pairs share the same featID1 
-            # (e.g. [1,2],[1,3]), select the feature pair with the minimum combination of 
+            # if multiple pairs share the same featID1
+            # (e.g. [1,2],[1,3]), select the feature pair with the minimum combination of
             # intersecting angle and distance
-            if featID1List.count(featID1) > 1: 
+            if featID1List.count(featID1) > 1:
                 indices = np.where(featID1Array == featID1)[0]
                 indexList = indices.tolist()
                 angleListTemp = []
@@ -2761,12 +3664,20 @@ def getAngle(inAngle):
                     dist = distList[index]
                     distListTemp.append(dist)
                 # call the getIndex()
-                j = self.getIndex(indexList,distListTemp,angleListTemp,distThreshold,angleThreshold,distWeight,angleWeight)
+                j = self.getIndex(
+                    indexList,
+                    distListTemp,
+                    angleListTemp,
+                    distThreshold,
+                    angleThreshold,
+                    distWeight,
+                    angleWeight,
+                )
                 ids1 = inIDListList[j]
                 # only append the list if it is not already in the existing list of lists
-                if ids1 not in outIDListList1:            
+                if ids1 not in outIDListList1:
                     outIDListList1.append(ids1)
-            else: # otherwise, just keep the pair
+            else:  # otherwise, just keep the pair
                 outIDListList1.append(ids)
             i += 1
         # update lists
@@ -2776,16 +3687,18 @@ def getAngle(inAngle):
             featID2List1.append(featID2List[i])
             distList1.append(distList[i])
             angleList1.append(angleList[i])
-            
-        # second round, doing features sharing featID2 
+
+        # second round, doing features sharing featID2
         # the inputs are the updated lists from the first round
-        outIDListList2 = [] #each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
+        outIDListList2 = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
         featID1List2 = []
         featID2List2 = []
         distList2 = []
-        angleList2 = []    
+        angleList2 = []
         i = 0
-        
+
         featID1Array = np.asarray(featID1List1)
         featID2Array = np.asarray(featID2List1)
         while i < len(outIDListList1):
@@ -2795,10 +3708,10 @@ def getAngle(inAngle):
             featID2 = featID2List1[i]
             dist = distList1[i]
             angle = angleList1[i]
-            # if multiple pairs share the same featID2 
-            # (e.g. [3,2],[4,2]), select the feature pair with the minimum combination of 
+            # if multiple pairs share the same featID2
+            # (e.g. [3,2],[4,2]), select the feature pair with the minimum combination of
             # intersecting angle and distance
-            if featID2List1.count(featID2) > 1: 
+            if featID2List1.count(featID2) > 1:
                 indices = np.where(featID2Array == featID2)[0]
                 indexList = indices.tolist()
                 angleListTemp = []
@@ -2808,12 +3721,20 @@ def getAngle(inAngle):
                     angleListTemp.append(angle)
                     dist = distList1[index]
                     distListTemp.append(dist)
-                j = self.getIndex(indexList,distListTemp,angleListTemp,distThreshold,angleThreshold,distWeight,angleWeight)
+                j = self.getIndex(
+                    indexList,
+                    distListTemp,
+                    angleListTemp,
+                    distThreshold,
+                    angleThreshold,
+                    distWeight,
+                    angleWeight,
+                )
                 ids1 = outIDListList1[j]
                 # only append the list if it is not already in the existing list of lists
-                if ids1 not in outIDListList2:            
+                if ids1 not in outIDListList2:
                     outIDListList2.append(ids1)
-            else: # otherwise, just keep the pair
+            else:  # otherwise, just keep the pair
                 outIDListList2.append(ids)
             i += 1
         for l in outIDListList2:
@@ -2822,11 +3743,22 @@ def getAngle(inAngle):
             featID2List2.append(featID2List1[i])
             distList2.append(distList1[i])
             angleList2.append(angleList1[i])
-        return featID1List2,featID2List2,outIDListList2,distList2,angleList2
+        return featID1List2, featID2List2, outIDListList2, distList2, angleList2
 
     # This function further updates ids list when multiple elements connected through sharing "from" and "to" points
     # must be called after doLists() (e.g., using the outputs from doLists() as inputs)
-    def doLists1(self,featID1List,featID2List,inIDListList,distList,angleList,distThreshold,angleThreshold,distWeight,angleWeight):
+    def doLists1(
+        self,
+        featID1List,
+        featID2List,
+        inIDListList,
+        distList,
+        angleList,
+        distThreshold,
+        angleThreshold,
+        distWeight,
+        angleWeight,
+    ):
         # featID1List: featIDs of the "from" points
         # featID2List: featIDs of the "to" points
         # inIDListList: list of [featID1,featID2]
@@ -2836,8 +3768,10 @@ def getAngle(inAngle):
         # angleThreshold: threshold value for the intersecting angle between two nearby features
         # distWeight: weight assigned to distance, used to calculate a combination metric from distance and angle (used in getIndex())
         # angleWeight: weight assigned to angle, used to calculate a combination metric from distance and angle (used in getIndex())
-                
-        outListList = [] #each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
+
+        outListList = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]],
         i = 0
         featID1Array = np.asarray(featID1List)
         featID2Array = np.asarray(featID2List)
@@ -2847,7 +3781,9 @@ def getAngle(inAngle):
             featID1 = featID1List[i]
             featID2 = featID2List[i]
 
-            if featID2List.count(featID1) > 0: # if two pairs (e.g., [2,1],[5,2]), indicates the three features are connected, so add both pairs
+            if (
+                featID2List.count(featID1) > 0
+            ):  # if two pairs (e.g., [2,1],[5,2]), indicates the three features are connected, so add both pairs
                 indices = np.where(featID2Array == featID1)[0]
                 indexList = indices.tolist()
                 angleListTemp = []
@@ -2857,14 +3793,24 @@ def getAngle(inAngle):
                     angleListTemp.append(angle)
                     dist = distList[index]
                     distListTemp.append(dist)
-                j = self.getIndex(indexList,distListTemp,angleListTemp,distThreshold,angleThreshold,distWeight,angleWeight)
+                j = self.getIndex(
+                    indexList,
+                    distListTemp,
+                    angleListTemp,
+                    distThreshold,
+                    angleThreshold,
+                    distWeight,
+                    angleWeight,
+                )
                 ids1 = inIDListList[j]
                 tempList.append(ids)
                 tempList.append(ids1)
                 tempList = self.getUnique(tempList)
                 if tempList not in outListList:
                     outListList.append(tempList)
-            elif featID1List.count(featID2) > 0: # if two pairs (e.g., [1,2],[2,5]), indicates the three features are connected, so add both pairs
+            elif (
+                featID1List.count(featID2) > 0
+            ):  # if two pairs (e.g., [1,2],[2,5]), indicates the three features are connected, so add both pairs
                 indices = np.where(featID1Array == featID2)[0]
                 indexList = indices.tolist()
                 angleListTemp = []
@@ -2874,50 +3820,59 @@ def getAngle(inAngle):
                     angleListTemp.append(angle)
                     dist = distList[index]
                     distListTemp.append(dist)
-                j = self.getIndex(indexList,distListTemp,angleListTemp,distThreshold,angleThreshold,distWeight,angleWeight)
+                j = self.getIndex(
+                    indexList,
+                    distListTemp,
+                    angleListTemp,
+                    distThreshold,
+                    angleThreshold,
+                    distWeight,
+                    angleWeight,
+                )
                 ids1 = inIDListList[j]
                 tempList.append(ids)
                 tempList.append(ids1)
                 tempList = self.getUnique(tempList)
                 if tempList not in outListList:
                     outListList.append(tempList)
-            else: # otherwise, just keep the pair
+            else:  # otherwise, just keep the pair
                 outListList.append(ids)
             i += 1
         return outListList
 
     # This function merges common elements from multiple lists into one list
-    def mergeList(self,inList):
+    def mergeList(self, inList):
         # inList: input list (of list) which contains multiple lists of featIDs
-        
-        tempListList1 = [] # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]], final results after more merge from tempListList
-        tempListListCopy = inList.copy() # deep copy
+
+        tempListList1 = (
+            []
+        )  # each element list contains ids of connected features e.g. [[1, 2, 3, 5], [4, 9], [6, 13]], final results after more merge from tempListList
+        tempListListCopy = inList.copy()  # deep copy
         # each loop remove an element list from inList, until none left
         # at the same time, build a new list (of list)
-        while len(inList) > 0: 
+        while len(inList) > 0:
             tempList = inList[0]
             tempListCopy = tempList.copy()
             # compare the element with all elements in the list one by one
             for tempList1 in tempListListCopy:
                 # call the helper function to find the number of common elements bewtween the two lists
-                leng = self.calculateCommon(tempListCopy,tempList1)
+                leng = self.calculateCommon(tempListCopy, tempList1)
                 if leng > 0:
                     inList.remove(tempList1)
                     for el in tempList1:
-                        tempListCopy.append(el)           
+                        tempListCopy.append(el)
                     # call the helper function to get the unique values within a list
                     tempList3 = self.getUnique(tempListCopy)
                     tempListCopy = tempList3.copy()
 
             list1 = list(flatten(tempListCopy))
             list2 = self.getUnique(list1)
-            tempListList1.append(list2)    
+            tempListList1.append(list2)
             tempListListCopy = inList.copy()
         return tempListList1
 
-
-    def createLists(self,linkFeatList):
-        # linkFeat1List: a list of input link features 
+    def createLists(self, linkFeatList):
+        # linkFeat1List: a list of input link features
         featID1List = []
         featID2List = []
         featIDListList = []
@@ -2944,34 +3899,34 @@ def getAngle(inAngle):
                     featIDListList.append(tempList)
 
                 del cursor, row
-        return featID1List,featID2List,featIDListList,distList,angleList
+        return featID1List, featID2List, featIDListList, distList, angleList
 
-        
-                
     # This function generate direction point features from the input features and the bounding rectangle features
     # This one would potentially resulted in a small number of incorrect points, e.g., two points on different features may be on the same line
-    def getDirectionPoints_old(self,inFeatClass,MbrLineClass,tempFolder,outPointFeat):
+    def getDirectionPoints_old(
+        self, inFeatClass, MbrLineClass, tempFolder, outPointFeat
+    ):
         # inFeatClass: featureclass represents the polygons to be connected (input Bathymetric High features)
         # MbrLineClass: a subset of the lines from the minimum bounding rectangles of inFeatClass; for each feature there are two lines, either N and S or E and W.
         # tempFolder: folder location to store temporary files
         # outPointFeat: output direction point features
-        
+
         inFeatVertices = "inFeatVertices"
-        # convert each input feature to points; 
-        arcpy.FeatureVerticesToPoints_management(inFeatClass,inFeatVertices,"ALL")
-        
+        # convert each input feature to points;
+        arcpy.FeatureVerticesToPoints_management(inFeatClass, inFeatVertices, "ALL")
+
         layer1 = "layer1"
-        arcpy.MakeFeatureLayer_management(inFeatVertices,layer1)
+        arcpy.MakeFeatureLayer_management(inFeatVertices, layer1)
         # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-        arcpy.SelectLayerByLocation_management(layer1,'INTERSECT',MbrLineClass)
+        arcpy.SelectLayerByLocation_management(layer1, "INTERSECT", MbrLineClass)
         selectedPoints = "selectedPoints1"
-        arcpy.CopyFeatures_management(layer1,selectedPoints)
+        arcpy.CopyFeatures_management(layer1, selectedPoints)
         # spatial join to append attributes from MbrLineClass
         joinFeat = "joinFeat"
-        arcpy.SpatialJoin_analysis(selectedPoints,MbrLineClass,joinFeat)
+        arcpy.SpatialJoin_analysis(selectedPoints, MbrLineClass, joinFeat)
 
         # only need these attributes, with additional POINT_X and POINT_Y attributes added
-        fieldsToKept = ['featID','rectangle_Orientation','direction']
+        fieldsToKept = ["featID", "rectangle_Orientation", "direction"]
         fieldsToDelete = []
         fields = arcpy.ListFields(joinFeat)
         for field in fields:
@@ -2979,19 +3934,19 @@ def getAngle(inAngle):
                 if not field.name in fieldsToKept:
                     fieldsToDelete.append(field.name)
 
-        arcpy.DeleteField_management(joinFeat,fieldsToDelete)
+        arcpy.DeleteField_management(joinFeat, fieldsToDelete)
         arcpy.AddXY_management(joinFeat)
 
-        # delete schema.ini which may contains incorrect data types 
+        # delete schema.ini which may contains incorrect data types
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
             os.remove(schemaFile)
         # export the attributes to a csv file
-        csvFile = tempFolder + '/joinFeat_points.csv'
-        arcpy.CopyRows_management(joinFeat,csvFile)
+        csvFile = tempFolder + "/joinFeat_points.csv"
+        arcpy.CopyRows_management(joinFeat, csvFile)
         # read the csv file as a pandas data frame
-        pointDF = pd.read_csv(csvFile,sep=',',header=0)
-        pointDF.set_index('OBJECTID',inplace=True)
+        pointDF = pd.read_csv(csvFile, sep=",", header=0)
+        pointDF.set_index("OBJECTID", inplace=True)
 
         idList = []
         angleList = []
@@ -3001,102 +3956,133 @@ def getAngle(inAngle):
         # loop through each feature
         for id in np.unique(pointDF.featID):
             # intend to select two points (e.g., E and W, W and E, N and S, S and N) for each input feature; each point requires one row
-            idList.append(id) # for first point (one element in the list)
-            idList.append(id) # for second point (next element in the list)
+            idList.append(id)  # for first point (one element in the list)
+            idList.append(id)  # for second point (next element in the list)
             # tempDF contains candidate points for a selected polygon feature
             tempDF = pointDF.loc[pointDF.featID == id]
-            angle = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.max()]['rectangle_Orientation'].values[0]            
+            angle = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.max()][
+                "rectangle_Orientation"
+            ].values[0]
             angleList.append(angle)
             angleList.append(angle)
             if (angle >= 45) & (angle <= 135):
                 # POINT_X.max() indicates E
-                direction = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.max()]['direction'].values[0]
+                direction = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.max()][
+                    "direction"
+                ].values[0]
                 dirList.append(direction)
-                x = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.max()]['POINT_X'].values[0]
+                x = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.max()][
+                    "POINT_X"
+                ].values[0]
                 xList.append(x)
-                y = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.max()]['POINT_Y'].values[0]
+                y = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.max()][
+                    "POINT_Y"
+                ].values[0]
                 yList.append(y)
                 # POINT_X.min() indicates W
-                direction = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.min()]['direction'].values[0]
+                direction = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.min()][
+                    "direction"
+                ].values[0]
                 dirList.append(direction)
-                x = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.min()]['POINT_X'].values[0]
+                x = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.min()][
+                    "POINT_X"
+                ].values[0]
                 xList.append(x)
-                y = tempDF.loc[tempDF.POINT_X==tempDF.POINT_X.min()]['POINT_Y'].values[0]
+                y = tempDF.loc[tempDF.POINT_X == tempDF.POINT_X.min()][
+                    "POINT_Y"
+                ].values[0]
                 yList.append(y)
             else:
                 # POINT_Y.max() indicates N
-                direction = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.max()]['direction'].values[0]
+                direction = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.max()][
+                    "direction"
+                ].values[0]
                 dirList.append(direction)
-                x = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.max()]['POINT_X'].values[0]
+                x = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.max()][
+                    "POINT_X"
+                ].values[0]
                 xList.append(x)
-                y = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.max()]['POINT_Y'].values[0]
+                y = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.max()][
+                    "POINT_Y"
+                ].values[0]
                 yList.append(y)
                 # POINT_Y.min() indicates S
-                direction = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.min()]['direction'].values[0]
+                direction = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.min()][
+                    "direction"
+                ].values[0]
                 dirList.append(direction)
-                x = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.min()]['POINT_X'].values[0]
+                x = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.min()][
+                    "POINT_X"
+                ].values[0]
                 xList.append(x)
-                y = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.min()]['POINT_Y'].values[0]
+                y = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.min()][
+                    "POINT_Y"
+                ].values[0]
                 yList.append(y)
 
         # create a new dataframe
         newPD = pd.DataFrame()
-        newPD['featID'] = idList
-        newPD['angle'] = angleList
-        newPD['direction'] = dirList
-        newPD['POINT_X'] = xList
-        newPD['POINT_Y'] = yList
+        newPD["featID"] = idList
+        newPD["angle"] = angleList
+        newPD["direction"] = dirList
+        newPD["POINT_X"] = xList
+        newPD["POINT_Y"] = yList
         # export the dataframe to a csv file
-        outFile = tempFolder + '/joinFeat_points1_selected.csv'
-        newPD.to_csv(outFile,sep=',',header=True)
+        outFile = tempFolder + "/joinFeat_points1_selected.csv"
+        newPD.to_csv(outFile, sep=",", header=True)
         # create point featureclass from the csv file
-        arcpy.XYTableToPoint_management(outFile,outPointFeat,'POINT_X','POINT_Y','#',MbrLineClass)
-##
-##        field = "direction"
-##        inID = "OBJECTID"
-##        joinID = "OBJECTID"
-##        expression = "!" + MbrLineClass + "." + "direction" + "!"
-##        self.addTextField(outPointFeat,MbrLineClass,field,inID,joinID,expression)
-##        # delete temporary data
-##        arcpy.Delete_management(inFeatVertices)
-##        arcpy.Delete_management(selectedPoints)
-##        arcpy.Delete_management(layer1)
-##        arcpy.Delete_management(outFile)
-##        arcpy.Delete_management(csvFile)
-                
+        arcpy.XYTableToPoint_management(
+            outFile, outPointFeat, "POINT_X", "POINT_Y", "#", MbrLineClass
+        )
+
+    ##
+    ##        field = "direction"
+    ##        inID = "OBJECTID"
+    ##        joinID = "OBJECTID"
+    ##        expression = "!" + MbrLineClass + "." + "direction" + "!"
+    ##        self.addTextField(outPointFeat,MbrLineClass,field,inID,joinID,expression)
+    ##        # delete temporary data
+    ##        arcpy.Delete_management(inFeatVertices)
+    ##        arcpy.Delete_management(selectedPoints)
+    ##        arcpy.Delete_management(layer1)
+    ##        arcpy.Delete_management(outFile)
+    ##        arcpy.Delete_management(csvFile)
+
     # This function generate direction point features from the input features and the bounding rectangle features
     # This works but is very time consuming
-    def getDirectionPoints_old1(self,inFeatClass,MbrLineClass,tempFolder,outPointFeat):
+    def getDirectionPoints_old1(
+        self, inFeatClass, MbrLineClass, tempFolder, outPointFeat
+    ):
         # inFeatClass: featureclass represents the polygons to be connected (input Bathymetric High features)
         # MbrLineClass: a subset of the lines from the minimum bounding rectangles of inFeatClass; for each feature there are two lines, either N and S or E and W.
         # tempFolder: folder location to store temporary files
         # outPointFeat: output direction point features
-        
+
         inFeatVertices = "inFeatVertices"
-        # convert each input feature to points; 
-        arcpy.FeatureVerticesToPoints_management(inFeatClass,inFeatVertices,"ALL")
-        
+        # convert each input feature to points;
+        arcpy.FeatureVerticesToPoints_management(inFeatClass, inFeatVertices, "ALL")
+
         layer1 = "layer1"
-        arcpy.MakeFeatureLayer_management(inFeatVertices,layer1)
+        arcpy.MakeFeatureLayer_management(inFeatVertices, layer1)
         # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-        arcpy.SelectLayerByLocation_management(layer1,'INTERSECT',MbrLineClass)
+        arcpy.SelectLayerByLocation_management(layer1, "INTERSECT", MbrLineClass)
         selectedPoints = "selectedPoints1"
-        arcpy.CopyFeatures_management(layer1,selectedPoints)
+        arcpy.CopyFeatures_management(layer1, selectedPoints)
         arcpy.AddXY_management(selectedPoints)
 
-        MbrLineN = 'MbrLineN'
-        MbrLineS = 'MbrLineS'
-        MbrLineE = 'MbrLineE'
-        MbrLineW = 'MbrLineW'
-        
+        MbrLineN = "MbrLineN"
+        MbrLineS = "MbrLineS"
+        MbrLineE = "MbrLineE"
+        MbrLineW = "MbrLineW"
+
         whereClause = "direction = 'N'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineN,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineN, whereClause)
         whereClause = "direction = 'S'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineS,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineS, whereClause)
         whereClause = "direction = 'E'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineE,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineE, whereClause)
         whereClause = "direction = 'W'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineW,whereClause)      
+        arcpy.Select_analysis(MbrLineClass, MbrLineW, whereClause)
 
         idList = []
         angleList = []
@@ -3112,20 +4098,20 @@ def getAngle(inAngle):
             idList.append(featID)
             angle = row.getValue("rectangle_Orientation")
             angleList.append(angle)
-            dirList.append('N')
-            tempFeat = 'tempFeat'
+            dirList.append("N")
+            tempFeat = "tempFeat"
             whereClause = "featID = " + str(featID)
-            arcpy.Select_analysis(selectedPoints,tempFeat,whereClause)
+            arcpy.Select_analysis(selectedPoints, tempFeat, whereClause)
 
-            tempFeat1 = 'tempFeat1'
-            arcpy.Select_analysis(MbrLineN,tempFeat1,whereClause)
-            
+            tempFeat1 = "tempFeat1"
+            arcpy.Select_analysis(MbrLineN, tempFeat1, whereClause)
+
             layerTemp = "layerTemp"
-            arcpy.MakeFeatureLayer_management(tempFeat,layerTemp)
+            arcpy.MakeFeatureLayer_management(tempFeat, layerTemp)
             # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-            arcpy.SelectLayerByLocation_management(layerTemp,'INTERSECT',tempFeat1)
+            arcpy.SelectLayerByLocation_management(layerTemp, "INTERSECT", tempFeat1)
             tempPoints = "tempPoints"
-            arcpy.CopyFeatures_management(layerTemp,tempPoints)
+            arcpy.CopyFeatures_management(layerTemp, tempPoints)
 
             cursor1 = arcpy.SearchCursor(tempPoints)
             row1 = cursor1.next()
@@ -3138,7 +4124,6 @@ def getAngle(inAngle):
             arcpy.Delete_management(tempFeat1)
             arcpy.Delete_management(tempPoints)
             arcpy.Delete_management(layerTemp)
-            
 
             del row1, cursor1
         del row, cursor
@@ -3151,20 +4136,20 @@ def getAngle(inAngle):
             idList.append(featID)
             angle = row.getValue("rectangle_Orientation")
             angleList.append(angle)
-            dirList.append('S')
-            tempFeat = 'tempFeat'
+            dirList.append("S")
+            tempFeat = "tempFeat"
             whereClause = "featID = " + str(featID)
-            arcpy.Select_analysis(selectedPoints,tempFeat,whereClause)
+            arcpy.Select_analysis(selectedPoints, tempFeat, whereClause)
 
-            tempFeat1 = 'tempFeat1'
-            arcpy.Select_analysis(MbrLineS,tempFeat1,whereClause)
-            
+            tempFeat1 = "tempFeat1"
+            arcpy.Select_analysis(MbrLineS, tempFeat1, whereClause)
+
             layerTemp = "layerTemp"
-            arcpy.MakeFeatureLayer_management(tempFeat,layerTemp)
+            arcpy.MakeFeatureLayer_management(tempFeat, layerTemp)
             # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-            arcpy.SelectLayerByLocation_management(layerTemp,'INTERSECT',tempFeat1)
+            arcpy.SelectLayerByLocation_management(layerTemp, "INTERSECT", tempFeat1)
             tempPoints = "tempPoints"
-            arcpy.CopyFeatures_management(layerTemp,tempPoints)
+            arcpy.CopyFeatures_management(layerTemp, tempPoints)
 
             cursor1 = arcpy.SearchCursor(tempPoints)
             row1 = cursor1.next()
@@ -3177,7 +4162,6 @@ def getAngle(inAngle):
             arcpy.Delete_management(tempFeat1)
             arcpy.Delete_management(tempPoints)
             arcpy.Delete_management(layerTemp)
-            
 
             del row1, cursor1
         del row, cursor
@@ -3190,20 +4174,20 @@ def getAngle(inAngle):
             idList.append(featID)
             angle = row.getValue("rectangle_Orientation")
             angleList.append(angle)
-            dirList.append('E')
-            tempFeat = 'tempFeat'
+            dirList.append("E")
+            tempFeat = "tempFeat"
             whereClause = "featID = " + str(featID)
-            arcpy.Select_analysis(selectedPoints,tempFeat,whereClause)
+            arcpy.Select_analysis(selectedPoints, tempFeat, whereClause)
 
-            tempFeat1 = 'tempFeat1'
-            arcpy.Select_analysis(MbrLineE,tempFeat1,whereClause)
-            
+            tempFeat1 = "tempFeat1"
+            arcpy.Select_analysis(MbrLineE, tempFeat1, whereClause)
+
             layerTemp = "layerTemp"
-            arcpy.MakeFeatureLayer_management(tempFeat,layerTemp)
+            arcpy.MakeFeatureLayer_management(tempFeat, layerTemp)
             # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-            arcpy.SelectLayerByLocation_management(layerTemp,'INTERSECT',tempFeat1)
+            arcpy.SelectLayerByLocation_management(layerTemp, "INTERSECT", tempFeat1)
             tempPoints = "tempPoints"
-            arcpy.CopyFeatures_management(layerTemp,tempPoints)
+            arcpy.CopyFeatures_management(layerTemp, tempPoints)
 
             cursor1 = arcpy.SearchCursor(tempPoints)
             row1 = cursor1.next()
@@ -3216,7 +4200,6 @@ def getAngle(inAngle):
             arcpy.Delete_management(tempFeat1)
             arcpy.Delete_management(tempPoints)
             arcpy.Delete_management(layerTemp)
-            
 
             del row1, cursor1
         del row, cursor
@@ -3229,20 +4212,20 @@ def getAngle(inAngle):
             idList.append(featID)
             angle = row.getValue("rectangle_Orientation")
             angleList.append(angle)
-            dirList.append('W')
-            tempFeat = 'tempFeat'
+            dirList.append("W")
+            tempFeat = "tempFeat"
             whereClause = "featID = " + str(featID)
-            arcpy.Select_analysis(selectedPoints,tempFeat,whereClause)
+            arcpy.Select_analysis(selectedPoints, tempFeat, whereClause)
 
-            tempFeat1 = 'tempFeat1'
-            arcpy.Select_analysis(MbrLineW,tempFeat1,whereClause)
-            
+            tempFeat1 = "tempFeat1"
+            arcpy.Select_analysis(MbrLineW, tempFeat1, whereClause)
+
             layerTemp = "layerTemp"
-            arcpy.MakeFeatureLayer_management(tempFeat,layerTemp)
+            arcpy.MakeFeatureLayer_management(tempFeat, layerTemp)
             # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-            arcpy.SelectLayerByLocation_management(layerTemp,'INTERSECT',tempFeat1)
+            arcpy.SelectLayerByLocation_management(layerTemp, "INTERSECT", tempFeat1)
             tempPoints = "tempPoints"
-            arcpy.CopyFeatures_management(layerTemp,tempPoints)
+            arcpy.CopyFeatures_management(layerTemp, tempPoints)
 
             cursor1 = arcpy.SearchCursor(tempPoints)
             row1 = cursor1.next()
@@ -3255,40 +4238,38 @@ def getAngle(inAngle):
             arcpy.Delete_management(tempFeat1)
             arcpy.Delete_management(tempPoints)
             arcpy.Delete_management(layerTemp)
-            
 
             del row1, cursor1
-        del row, cursor            
-
-        
-              
+        del row, cursor
 
         # create a new dataframe
         newPD = pd.DataFrame()
-        newPD['featID'] = idList
-        newPD['angle'] = angleList
-        newPD['direction'] = dirList
-        newPD['POINT_X'] = xList
-        newPD['POINT_Y'] = yList
+        newPD["featID"] = idList
+        newPD["angle"] = angleList
+        newPD["direction"] = dirList
+        newPD["POINT_X"] = xList
+        newPD["POINT_Y"] = yList
         # export the dataframe to a csv file
-        outFile = tempFolder + '/joinFeat_points1_selected.csv'
-        newPD.to_csv(outFile,sep=',',header=True)
+        outFile = tempFolder + "/joinFeat_points1_selected.csv"
+        newPD.to_csv(outFile, sep=",", header=True)
         # create point featureclass from the csv file
-        arcpy.XYTableToPoint_management(outFile,outPointFeat,'POINT_X','POINT_Y','#',MbrLineClass)
+        arcpy.XYTableToPoint_management(
+            outFile, outPointFeat, "POINT_X", "POINT_Y", "#", MbrLineClass
+        )
 
-##        # delete temporary data
-##        arcpy.Delete_management(inFeatVertices)
-##        arcpy.Delete_management(selectedPoints)
-##        arcpy.Delete_management(layer1)
-##        arcpy.Delete_management(outFile)
-##        arcpy.Delete_management(MbrLineN)
-##        arcpy.Delete_management(MbrLineS)
-##        arcpy.Delete_management(MbrLineE)
-##        arcpy.Delete_management(MbrLineW)
-                
+    ##        # delete temporary data
+    ##        arcpy.Delete_management(inFeatVertices)
+    ##        arcpy.Delete_management(selectedPoints)
+    ##        arcpy.Delete_management(layer1)
+    ##        arcpy.Delete_management(outFile)
+    ##        arcpy.Delete_management(MbrLineN)
+    ##        arcpy.Delete_management(MbrLineS)
+    ##        arcpy.Delete_management(MbrLineE)
+    ##        arcpy.Delete_management(MbrLineW)
+
     # This function generate direction point features from the input features.
     # Two points are generated for each feature at its north and south sides or its east and west sides.
-    def getDirectionPoints(self,inFeatClass,MbrLineClass,tempFolder,outPointFeat):
+    def getDirectionPoints(self, inFeatClass, MbrLineClass, tempFolder, outPointFeat):
         # inFeatClass: featureclass represents the polygons to be connected (input Bathymetric High or Low features)
         # MbrLineClass: a subset of the lines from the minimum bounding rectangles of inFeatClass; for each feature there are two lines, either N and S or E and W.
         # tempFolder: folder location to store temporary files
@@ -3296,14 +4277,14 @@ def getAngle(inAngle):
         itemList = []
         inFeatVertices = "inFeatVertices"
         itemList.append(inFeatVertices)
-        # convert each input feature to points; 
-        arcpy.FeatureVerticesToPoints_management(inFeatClass,inFeatVertices,"ALL")
+        # convert each input feature to points;
+        arcpy.FeatureVerticesToPoints_management(inFeatClass, inFeatVertices, "ALL")
         # for each polygon, the first vertice and the last vertice are identical, need to remove the duplicate
         verticeTab = "verticeTab"
         itemList.append(verticeTab)
         statsField = [["OBJECTID", "MIN"]]
         caseField = "featID"
-        arcpy.Statistics_analysis(inFeatVertices,verticeTab,statsField,caseField)
+        arcpy.Statistics_analysis(inFeatVertices, verticeTab, statsField, caseField)
 
         idList = []
         cursor = arcpy.SearchCursor(verticeTab)
@@ -3315,56 +4296,55 @@ def getAngle(inAngle):
         inFeatVertices1 = "inFeatVertices1"
         itemList.append(inFeatVertices1)
         # select subset
-        text = '('
+        text = "("
         for j in idList:
-            text = text + str(j) + ','
-        text = text[0:-1] + ')'
-        whereClause = 'OBJECTID NOT IN ' + text
-        arcpy.Select_analysis(inFeatVertices,inFeatVertices1,whereClause)
-        
+            text = text + str(j) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID NOT IN " + text
+        arcpy.Select_analysis(inFeatVertices, inFeatVertices1, whereClause)
+
         # select polygon points on the bounding rectangle boundaries
         layer1 = "layer1"
         itemList.append(layer1)
-        arcpy.MakeFeatureLayer_management(inFeatVertices1,layer1)
+        arcpy.MakeFeatureLayer_management(inFeatVertices1, layer1)
         # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-        arcpy.SelectLayerByLocation_management(layer1,'INTERSECT',MbrLineClass)
+        arcpy.SelectLayerByLocation_management(layer1, "INTERSECT", MbrLineClass)
         selectedPoints = "selectedPoints1"
         itemList.append(selectedPoints)
-        arcpy.CopyFeatures_management(layer1,selectedPoints)
+        arcpy.CopyFeatures_management(layer1, selectedPoints)
         arcpy.AddXY_management(selectedPoints)
 
-        
         # separate into four boundary types
-        MbrLineN = 'MbrLineN'
-        MbrLineS = 'MbrLineS'
-        MbrLineE = 'MbrLineE'
-        MbrLineW = 'MbrLineW'
+        MbrLineN = "MbrLineN"
+        MbrLineS = "MbrLineS"
+        MbrLineE = "MbrLineE"
+        MbrLineW = "MbrLineW"
         itemList.append(MbrLineN)
         itemList.append(MbrLineS)
         itemList.append(MbrLineE)
         itemList.append(MbrLineW)
-        
+
         whereClause = "direction = 'N'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineN,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineN, whereClause)
         whereClause = "direction = 'S'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineS,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineS, whereClause)
         whereClause = "direction = 'E'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineE,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineE, whereClause)
         whereClause = "direction = 'W'"
-        arcpy.Select_analysis(MbrLineClass,MbrLineW,whereClause)
+        arcpy.Select_analysis(MbrLineClass, MbrLineW, whereClause)
 
         # when the orientation is straight north (=0) or straight east (=90), multiple points can be on the boundaries
         # in this case, need to select only one point (first point) for each boundary
         selectedPoints_1 = "selectedPoints1_1"
         itemList.append(selectedPoints_1)
         whereClause = "rectangle_Orientation = 0"
-        arcpy.Select_analysis(selectedPoints,selectedPoints_1,whereClause)
-        
+        arcpy.Select_analysis(selectedPoints, selectedPoints_1, whereClause)
+
         tab1 = "tab1"
         itemList.append(tab1)
         statsField = [["OBJECTID", "MIN"]]
-        caseField = ["featID","POINT_Y"]
-        arcpy.Statistics_analysis(selectedPoints_1,tab1,statsField,caseField)
+        caseField = ["featID", "POINT_Y"]
+        arcpy.Statistics_analysis(selectedPoints_1, tab1, statsField, caseField)
 
         idList = []
         cursor = arcpy.SearchCursor(tab1)
@@ -3372,57 +4352,55 @@ def getAngle(inAngle):
             oID = row.getValue("MIN_OBJECTID")
             idList.append(oID)
         del cursor, row
-        
+
         selectedPoints_1_1 = "selectedPoints1_1_1"
         itemList.append(selectedPoints_1_1)
         # select subset
-        text = '('
+        text = "("
         for j in idList:
-            text = text + str(j) + ','
-        text = text[0:-1] + ')'
-        whereClause = 'OBJECTID IN ' + text
-        arcpy.Select_analysis(selectedPoints_1,selectedPoints_1_1,whereClause)
-        
+            text = text + str(j) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
+        arcpy.Select_analysis(selectedPoints_1, selectedPoints_1_1, whereClause)
 
         selectedPoints_2 = "selectedPoints1_2"
         itemList.append(selectedPoints_2)
         whereClause = "rectangle_Orientation = 90"
-        arcpy.Select_analysis(selectedPoints,selectedPoints_2,whereClause)
-        
+        arcpy.Select_analysis(selectedPoints, selectedPoints_2, whereClause)
+
         tab2 = "tab2"
         itemList.append(tab2)
         statsField = [["OBJECTID", "MIN"]]
-        caseField = ["featID","POINT_X"]
-        arcpy.Statistics_analysis(selectedPoints_2,tab2,statsField,caseField)
+        caseField = ["featID", "POINT_X"]
+        arcpy.Statistics_analysis(selectedPoints_2, tab2, statsField, caseField)
 
         idList = []
         cursor = arcpy.SearchCursor(tab2)
         for row in cursor:
             oID = row.getValue("MIN_OBJECTID")
             idList.append(oID)
-        del cursor, row        
-        
+        del cursor, row
 
         selectedPoints_2_1 = "selectedPoints1_2_1"
         itemList.append(selectedPoints_2_1)
         # select subset
-        text = '('
+        text = "("
         for j in idList:
-            text = text + str(j) + ','
-        text = text[0:-1] + ')'
-        whereClause = 'OBJECTID IN ' + text
-        arcpy.Select_analysis(selectedPoints_2,selectedPoints_2_1,whereClause)
+            text = text + str(j) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
+        arcpy.Select_analysis(selectedPoints_2, selectedPoints_2_1, whereClause)
         # select those points that are not from features orienting straight north and straight east
         selectedPoints_4 = "selectedPoints1_4"
         itemList.append(selectedPoints_4)
         whereClause = "(rectangle_Orientation <> 0) And (rectangle_Orientation <> 90)"
-        arcpy.Select_analysis(selectedPoints,selectedPoints_4,whereClause)
+        arcpy.Select_analysis(selectedPoints, selectedPoints_4, whereClause)
         # merge these three subsets to form a new set of points
         selectedPoints1 = "selectedPoints2"
         itemList.append(selectedPoints1)
-        inputs = [selectedPoints_1_1,selectedPoints_2_1,selectedPoints_4]
-        arcpy.Merge_management(inputs,selectedPoints1)        
-        
+        inputs = [selectedPoints_1_1, selectedPoints_2_1, selectedPoints_4]
+        arcpy.Merge_management(inputs, selectedPoints1)
+
         # call the function to generate direction lists
         idList = []
         angleList = []
@@ -3430,29 +4408,50 @@ def getAngle(inAngle):
         xList = []
         yList = []
 
-        idList,angleList,dirList,xList,yList = self.generateDirectionPointLists(selectedPoints1,MbrLineN,idList,angleList,dirList,xList,yList,'N')
-        idList,angleList,dirList,xList,yList = self.generateDirectionPointLists(selectedPoints1,MbrLineS,idList,angleList,dirList,xList,yList,'S')
-        idList,angleList,dirList,xList,yList = self.generateDirectionPointLists(selectedPoints1,MbrLineE,idList,angleList,dirList,xList,yList,'E')
-        idList,angleList,dirList,xList,yList = self.generateDirectionPointLists(selectedPoints1,MbrLineW,idList,angleList,dirList,xList,yList,'W')
-        
+        idList, angleList, dirList, xList, yList = self.generateDirectionPointLists(
+            selectedPoints1, MbrLineN, idList, angleList, dirList, xList, yList, "N"
+        )
+        idList, angleList, dirList, xList, yList = self.generateDirectionPointLists(
+            selectedPoints1, MbrLineS, idList, angleList, dirList, xList, yList, "S"
+        )
+        idList, angleList, dirList, xList, yList = self.generateDirectionPointLists(
+            selectedPoints1, MbrLineE, idList, angleList, dirList, xList, yList, "E"
+        )
+        idList, angleList, dirList, xList, yList = self.generateDirectionPointLists(
+            selectedPoints1, MbrLineW, idList, angleList, dirList, xList, yList, "W"
+        )
+
         # create a new dataframe
         newPD = pd.DataFrame()
-        newPD['featID'] = idList
-        newPD['angle'] = angleList
-        newPD['direction'] = dirList
-        newPD['POINT_X'] = xList
-        newPD['POINT_Y'] = yList
+        newPD["featID"] = idList
+        newPD["angle"] = angleList
+        newPD["direction"] = dirList
+        newPD["POINT_X"] = xList
+        newPD["POINT_Y"] = yList
         # export the dataframe to a csv file
-        outFile = tempFolder + '/points1_selected.csv'
+        outFile = tempFolder + "/points1_selected.csv"
         itemList.append(outFile)
-        newPD.to_csv(outFile,sep=',',header=True)
+        newPD.to_csv(outFile, sep=",", header=True)
         # create point featureclass from the csv file
-        arcpy.XYTableToPoint_management(outFile,outPointFeat,'POINT_X','POINT_Y','#',MbrLineClass)
+        arcpy.XYTableToPoint_management(
+            outFile, outPointFeat, "POINT_X", "POINT_Y", "#", MbrLineClass
+        )
 
         # delete temporary data
         self.deleteDataItems(itemList)
-    # This function generates five lists from the direction points input featureclass.            
-    def generateDirectionPointLists(self,pointFeat,MbrlineFeat,idList,angleList,dirList,xList,yList,direction):
+
+    # This function generates five lists from the direction points input featureclass.
+    def generateDirectionPointLists(
+        self,
+        pointFeat,
+        MbrlineFeat,
+        idList,
+        angleList,
+        dirList,
+        xList,
+        yList,
+        direction,
+    ):
         # pointFeat: input direction points featureclass
         # MbrlineFeat: input bounding rectangle boundaries featueclass
         # idList: output list of featIDs
@@ -3464,19 +4463,19 @@ def getAngle(inAngle):
         itemList = []
         layerTemp = "layerTemp"
         itemList.append(layerTemp)
-        arcpy.MakeFeatureLayer_management(pointFeat,layerTemp)
+        arcpy.MakeFeatureLayer_management(pointFeat, layerTemp)
         # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-        arcpy.SelectLayerByLocation_management(layerTemp,'INTERSECT',MbrlineFeat)
+        arcpy.SelectLayerByLocation_management(layerTemp, "INTERSECT", MbrlineFeat)
         selectedPointsTemp = "selectedPointsTemp"
         itemList.append(layerTemp)
-        arcpy.CopyFeatures_management(layerTemp,selectedPointsTemp)
+        arcpy.CopyFeatures_management(layerTemp, selectedPointsTemp)
 
         # build two featID lists: one contains features with only one candidate point; the other contains mutliple candidate points
         sumTab = "sumTab"
         itemList.append(sumTab)
         statsField = [["featID", "COUNT"]]
         caseField = "featID"
-        arcpy.Statistics_analysis(selectedPointsTemp,sumTab,statsField,caseField)
+        arcpy.Statistics_analysis(selectedPointsTemp, sumTab, statsField, caseField)
         featIDList1 = []
         featIDList2 = []
         cursor = arcpy.SearchCursor(sumTab)
@@ -3488,20 +4487,17 @@ def getAngle(inAngle):
             else:
                 featIDList1.append(featID)
         del cursor, row
-        
-        
 
         if len(featIDList1) > 0:
             # select subset
-            text = '('
+            text = "("
             for j in featIDList1:
-                text = text + str(j) + ','
-            text = text[0:-1] + ')'
-            whereClause = 'featID IN ' + text
-            selectedPointsTemp1 = 'selectedPoints1Temp1'
+                text = text + str(j) + ","
+            text = text[0:-1] + ")"
+            whereClause = "featID IN " + text
+            selectedPointsTemp1 = "selectedPoints1Temp1"
             itemList.append(selectedPointsTemp1)
-            arcpy.Select_analysis(selectedPointsTemp,selectedPointsTemp1,whereClause)
-
+            arcpy.Select_analysis(selectedPointsTemp, selectedPointsTemp1, whereClause)
 
         # deal with the first subset
         inFeatCount = int(arcpy.GetCount_management(selectedPointsTemp1).getOutput(0))
@@ -3524,26 +4520,27 @@ def getAngle(inAngle):
             # deal with the second subset
             for idV in featIDList2:
                 arcpy.AddMessage("idV: " + str(idV))
-                tempFeat = 'tempFeat'
+                tempFeat = "tempFeat"
                 whereClause = "featID = " + str(idV)
-                arcpy.Select_analysis(pointFeat,tempFeat,whereClause)
+                arcpy.Select_analysis(pointFeat, tempFeat, whereClause)
 
-                tempFeat1 = 'tempFeat1'
-                arcpy.Select_analysis(MbrlineFeat,tempFeat1,whereClause)
-                
-                
+                tempFeat1 = "tempFeat1"
+                arcpy.Select_analysis(MbrlineFeat, tempFeat1, whereClause)
+
                 layerTemp1 = "layerTemp1"
-                arcpy.MakeFeatureLayer_management(tempFeat,layerTemp1)
+                arcpy.MakeFeatureLayer_management(tempFeat, layerTemp1)
                 # select those points that are on the selected bounding rectangle boundaries (N and S or E and W)
-                arcpy.SelectLayerByLocation_management(layerTemp1,'INTERSECT',tempFeat1)
+                arcpy.SelectLayerByLocation_management(
+                    layerTemp1, "INTERSECT", tempFeat1
+                )
                 tempPoints = "tempPoints"
-                arcpy.CopyFeatures_management(layerTemp1,tempPoints)
-                
+                arcpy.CopyFeatures_management(layerTemp1, tempPoints)
+
                 inFeatCount = int(arcpy.GetCount_management(tempPoints).getOutput(0))
                 if inFeatCount > 0:
                     idList.append(idV)
                     cursor1 = arcpy.SearchCursor(tempPoints)
-                    row1 = cursor1.next() # get the first candidate point
+                    row1 = cursor1.next()  # get the first candidate point
                     pointX = row1.getValue("POINT_X")
                     pointY = row1.getValue("POINT_Y")
                     xList.append(pointX)
@@ -3558,99 +4555,100 @@ def getAngle(inAngle):
                 arcpy.Delete_management(tempPoints)
                 arcpy.Delete_management(layerTemp)
 
-
         self.deleteDataItems(itemList)
-        return idList,angleList,dirList,xList,yList
+        return idList, angleList, dirList, xList, yList
 
     # This function selects a subset of input links.
-    def selectLinks(self,inLinksFeat,pointsFeatFrom,pointsFeatTo,outLinksFeat):
+    def selectLinks(self, inLinksFeat, pointsFeatFrom, pointsFeatTo, outLinksFeat):
         # inLinksFeat: input links featureclass
         # pointsFeatFrom: featureclass represents the from point of a link
         # pointsFeatTo: featureclass represents the to point of a link
         # outLinksFeat: output the subset of links after the selection process
-        
+
         # add and calculate fields
         field1 = "featID1"
-        field2 = "fromLocation" # location of the origin features (e.g., F and H)
-        field3 = "fromDirection" # orientation of the origin features (e.g., N, S, E and W)
+        field2 = "fromLocation"  # location of the origin features (e.g., F and H)
+        field3 = (
+            "fromDirection"  # orientation of the origin features (e.g., N, S, E and W)
+        )
         inID = "ORIG_FID"
         joinID = "OBJECTID"
         expression = "!" + pointsFeatFrom + "." + "featID" + "!"
-        self.addLongField(inLinksFeat,pointsFeatFrom,field1,inID,joinID,expression)
+        self.addLongField(inLinksFeat, pointsFeatFrom, field1, inID, joinID, expression)
         expression = "!" + pointsFeatFrom + "." + "location" + "!"
-        self.addTextField(inLinksFeat,pointsFeatFrom,field2,inID,joinID,expression)
+        self.addTextField(inLinksFeat, pointsFeatFrom, field2, inID, joinID, expression)
         expression = "!" + pointsFeatFrom + "." + "direction" + "!"
-        self.addTextField(inLinksFeat,pointsFeatFrom,field3,inID,joinID,expression)
-        
+        self.addTextField(inLinksFeat, pointsFeatFrom, field3, inID, joinID, expression)
+
         field1 = "featID2"
-        field2 = "toLocation" # location of the destination features
-        field3 = "toDirection" # orientation of the destination features
+        field2 = "toLocation"  # location of the destination features
+        field3 = "toDirection"  # orientation of the destination features
         inID = "DEST_FID"
         joinID = "OBJECTID"
         expression = "!" + pointsFeatTo + "." + "featID" + "!"
-        self.addLongField(inLinksFeat,pointsFeatTo,field1,inID,joinID,expression)
+        self.addLongField(inLinksFeat, pointsFeatTo, field1, inID, joinID, expression)
         expression = "!" + pointsFeatTo + "." + "location" + "!"
-        self.addTextField(inLinksFeat,pointsFeatTo,field2,inID,joinID,expression)
+        self.addTextField(inLinksFeat, pointsFeatTo, field2, inID, joinID, expression)
         expression = "!" + pointsFeatTo + "." + "direction" + "!"
-        self.addTextField(inLinksFeat,pointsFeatTo,field3,inID,joinID,expression)
+        self.addTextField(inLinksFeat, pointsFeatTo, field3, inID, joinID, expression)
 
         # add more fields
         fieldName1 = "idDiff"
         fieldType = "LONG"
         fieldPrecision = 15
-        arcpy.AddField_management(inLinksFeat,fieldName1,fieldType,fieldPrecision)
+        arcpy.AddField_management(inLinksFeat, fieldName1, fieldType, fieldPrecision)
 
         expression = "!featID1! - !featID2!"
-        arcpy.CalculateField_management(inLinksFeat,fieldName1,expression)
+        arcpy.CalculateField_management(inLinksFeat, fieldName1, expression)
         linksFeat1Temp = "links1Temp"
-        whereClause = 'idDiff <> 0'
-        arcpy.Select_analysis(inLinksFeat,linksFeat1Temp,whereClause)
+        whereClause = "idDiff <> 0"
+        arcpy.Select_analysis(inLinksFeat, linksFeat1Temp, whereClause)
 
         # generate summary statistics
-        tab1 = 'tab1'
+        tab1 = "tab1"
         statsField = [["LINK_DIST", "MIN"]]
         caseField = "featID1"
-        arcpy.Statistics_analysis(linksFeat1Temp,tab1,statsField,caseField)
+        arcpy.Statistics_analysis(linksFeat1Temp, tab1, statsField, caseField)
 
         fieldName2 = "distDiff"
         inID = "featID1"
         joinID = "featID1"
         expression = "!" + linksFeat1Temp + ".LINK_DIST! - !" + tab1 + ".MIN_LINK_DIST!"
-        self.addField(linksFeat1Temp,tab1,fieldName2,inID,joinID,expression)
+        self.addField(linksFeat1Temp, tab1, fieldName2, inID, joinID, expression)
         # select a subset o links based on the following condition
         linksFeat2Temp = "links2Temp"
-        whereClause = 'distDiff = 0'
-        arcpy.Select_analysis(linksFeat1Temp,linksFeat2Temp,whereClause)
+        whereClause = "distDiff = 0"
+        arcpy.Select_analysis(linksFeat1Temp, linksFeat2Temp, whereClause)
         # further selection based on the following condition
         whereClause = "(fromLocation = 'F') And (toLocation = 'H')"
-        arcpy.Select_analysis(linksFeat2Temp,outLinksFeat,whereClause)
+        arcpy.Select_analysis(linksFeat2Temp, outLinksFeat, whereClause)
 
         arcpy.Delete_management(linksFeat1Temp)
         arcpy.Delete_management(linksFeat2Temp)
         arcpy.Delete_management(tab1)
-        
+
     # This function identifies the input points as either head (H) points or foot (F) points.
-    def toFHpoints(self,inPointFeat,mosaicBathy,tempFolder,outPointFeat):
+    def toFHpoints(self, inPointFeat, mosaicBathy, tempFolder, outPointFeat):
         # inPointFeat: input featureclass represents direction points
         # mosaicBathy: input bathymetry data
         # tempFolder: the tempFolder to store temporary files
         # outPointFeat: output point featureclass with a new field indicating the H or F location
-        
-        pointFeatTemp = 'pointFeatTemp'
+
+        pointFeatTemp = "pointFeatTemp"
         # to identify a point as either H or F point, we need to obtain the bathymetry value for this point
-        ExtractValuesToPoints(inPointFeat,mosaicBathy,pointFeatTemp)
+        ExtractValuesToPoints(inPointFeat, mosaicBathy, pointFeatTemp)
         arcpy.AddMessage("extract depth values done")
 
-        # delete schema.ini which may contains incorrect data types 
+        # delete schema.ini which may contains incorrect data types
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
             os.remove(schemaFile)
         # export the attributes to a csv file
-        csvFile = tempFolder + '/pointFeat1.csv'
-        arcpy.CopyRows_management(pointFeatTemp,csvFile)
+        csvFile = tempFolder + "/pointFeat1.csv"
+        arcpy.CopyRows_management(pointFeatTemp, csvFile)
         # read the csv file as a pandas data frame
-        pointDF = pd.read_csv(csvFile,sep=',',header=0)
-        pointDF.set_index('OBJECTID',inplace=True)
+        pointDF = pd.read_csv(csvFile, sep=",", header=0)
+        pointDF.set_index("OBJECTID", inplace=True)
 
         idList = []
         angleList = []
@@ -3661,61 +4659,62 @@ def getAngle(inAngle):
         # loop through each feature
         for id in np.unique(pointDF.featID):
             # intend to select two points (e.g., E and W, W and E, N and S, S and N) for each input feature; each point requires one row
-            idList.append(id) # for first point (one element in the list)
-            idList.append(id) # for second point (next element in the list)
+            idList.append(id)  # for first point (one element in the list)
+            idList.append(id)  # for second point (next element in the list)
             # tempDF contains candidate points for a selected polygon feature
             tempDF = pointDF.loc[pointDF.featID == id]
-            angle = tempDF.loc[tempDF.POINT_Y==tempDF.POINT_Y.max()]['angle'].values[0]            
+            angle = tempDF.loc[tempDF.POINT_Y == tempDF.POINT_Y.max()]["angle"].values[
+                0
+            ]
             angleList.append(angle)
             angleList.append(angle)
 
             # RASTERVALU.max() indicates head
-            x = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.max()]['POINT_X'].values[0]
+            x = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.max()][
+                "POINT_X"
+            ].values[0]
             xList.append(x)
-            y = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.max()]['POINT_Y'].values[0]
+            y = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.max()][
+                "POINT_Y"
+            ].values[0]
             yList.append(y)
-            dirV = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.max()]['direction'].values[0]
+            dirV = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.max()][
+                "direction"
+            ].values[0]
             dirList.append(dirV)
-            locList.append('H')
+            locList.append("H")
             # RASTERVALU.min() indicates foot
-            x = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.min()]['POINT_X'].values[0]
+            x = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.min()][
+                "POINT_X"
+            ].values[0]
             xList.append(x)
-            y = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.min()]['POINT_Y'].values[0]
+            y = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.min()][
+                "POINT_Y"
+            ].values[0]
             yList.append(y)
-            dirV = tempDF.loc[tempDF.RASTERVALU==tempDF.RASTERVALU.min()]['direction'].values[0]
+            dirV = tempDF.loc[tempDF.RASTERVALU == tempDF.RASTERVALU.min()][
+                "direction"
+            ].values[0]
             dirList.append(dirV)
-            locList.append('F')
+            locList.append("F")
 
         # create a new dataframe
         newPD = pd.DataFrame()
-        newPD['featID'] = idList
-        newPD['angle'] = angleList
-        newPD['direction'] = dirList
-        newPD['location'] = locList
-        newPD['POINT_X'] = xList
-        newPD['POINT_Y'] = yList
+        newPD["featID"] = idList
+        newPD["angle"] = angleList
+        newPD["direction"] = dirList
+        newPD["location"] = locList
+        newPD["POINT_X"] = xList
+        newPD["POINT_Y"] = yList
         # export the dataframe to a csv file
-        outFile = tempFolder + '/pointFeat2.csv'
-        newPD.to_csv(outFile,sep=',',header=True)
-        # create point featureclass from the csv file        
-        arcpy.XYTableToPoint_management(outFile,outPointFeat,'POINT_X','POINT_Y','#',inPointFeat)
+        outFile = tempFolder + "/pointFeat2.csv"
+        newPD.to_csv(outFile, sep=",", header=True)
+        # create point featureclass from the csv file
+        arcpy.XYTableToPoint_management(
+            outFile, outPointFeat, "POINT_X", "POINT_Y", "#", inPointFeat
+        )
 
         # delete temporary data
         arcpy.Delete_management(pointFeatTemp)
         arcpy.Delete_management(csvFile)
         arcpy.Delete_management(outFile)
-        
-
-        
-
-        
-      
-
-        
-        
-        
-
-        
-                                        
-        
-        

--- a/Tools/AddAttributes.pyt
+++ b/Tools/AddAttributes.pyt
@@ -5,20 +5,20 @@
 #### Python version: 3+
 #### ArcGIS Pro: 2.6.4 and above
 
-import arcpy
-from arcpy import env
-from arcpy.sa import *
-import os
 import math
-from datetime import datetime 
+import os
+from datetime import datetime
+
+import arcpy
 import numpy as np
 import pandas as pd
-from collections import Counter
-import sys
+from arcpy import env
+from arcpy.sa import *
+
 arcpy.CheckOutExtension("Spatial")
 
 
-class Toolbox(object):
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -28,11 +28,17 @@ class Toolbox(object):
         # List of tool classes associated with this toolbox
         # There are six tools. Three for generating attributes for Bathymetric High features. The other three for Bathymetric Low features.
         # The three tools are used to add three sets of attributes: shape attributes, topographic attributes and profile attributes, in that order.
-        self.tools = [Add_Shape_Attributes_High_Tool,Add_Shape_Attributes_Low_Tool,Add_Profile_Attributes_High_Tool,Add_Profile_Attributes_Low_Tool,Add_Topographic_Attributes_High_Tool,Add_Topographic_Attributes_Low_Tool]
+        self.tools = [
+            Add_Shape_Attributes_High_Tool,
+            Add_Shape_Attributes_Low_Tool,
+            Add_Profile_Attributes_High_Tool,
+            Add_Profile_Attributes_Low_Tool,
+            Add_Topographic_Attributes_High_Tool,
+            Add_Topographic_Attributes_Low_Tool,
+        ]
 
 
-
-class Add_Shape_Attributes_High_Tool(object):
+class Add_Shape_Attributes_High_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Shape Attributes High Tool"
@@ -48,16 +54,17 @@ class Add_Shape_Attributes_High_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
-        
         # second parameter
         param1 = arcpy.Parameter(
             displayName="Output Features",
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
 
         # third parameter
@@ -66,17 +73,18 @@ class Add_Shape_Attributes_High_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
-        
-      # fourth parameter, used to hold temporaray files
+            direction="Input",
+        )
+
+        # fourth parameter, used to hold temporaray files
         param3 = arcpy.Parameter(
             displayName="Temporary Folder",
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
+            direction="Input",
+        )
 
-        
         parameters = [param0, param1, param2, param3]
         return parameters
 
@@ -88,7 +96,6 @@ class Add_Shape_Attributes_High_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -99,12 +106,12 @@ class Add_Shape_Attributes_High_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         inBathy = parameters[2].valueAsText
         tempFolder = parameters[3].valueAsText
-        
+
         # calling the helper functions
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
@@ -116,74 +123,84 @@ class Add_Shape_Attributes_High_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
-        
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
+
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
                         inBathy = helper.convert_backslach_forwardslach(lyr.dataSource)
 
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
-        
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-        
+            helper.addIDField(inFeatClass, "featID")
+
         # calculate compactness attribute
         helper.calculateCompactness(inFeatClass)
         # calculate circularity, convexity and solidity attributes
         helper.calculateCircularity_Convexity_Solidity(inFeatClass)
         # calculate sinuosity, length to width ratio, and other shape attributes
-        helper.calculateSinuosity_LwR(workspaceName,tempFolder,inFeatClass,inBathy)
+        helper.calculateSinuosity_LwR(workspaceName, tempFolder, inFeatClass, inBathy)
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
         arcpy.AddMessage("Compacted the geodatabase")
-  
 
         return
 
-class Add_Shape_Attributes_Low_Tool(object):
+
+class Add_Shape_Attributes_Low_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Shape Attributes Low Tool"
@@ -199,15 +216,17 @@ class Add_Shape_Attributes_Low_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
-        
+            direction="Input",
+        )
+
         # second parameter
         param1 = arcpy.Parameter(
             displayName="Output Features",
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
 
         # third parameter
@@ -216,15 +235,17 @@ class Add_Shape_Attributes_Low_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
-        
-      # fourth parameter
+            direction="Input",
+        )
+
+        # fourth parameter
         param3 = arcpy.Parameter(
             displayName="Temporary Folder",
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
+            direction="Input",
+        )
 
         # fifth parameter
         param4 = arcpy.Parameter(
@@ -232,7 +253,8 @@ class Add_Shape_Attributes_Low_Tool(object):
             name="headFeatClass",
             datatype="DEFeatureClass",
             parameterType="required",
-            direction="Output")
+            direction="Output",
+        )
 
         # sixth parameter
         param5 = arcpy.Parameter(
@@ -240,7 +262,8 @@ class Add_Shape_Attributes_Low_Tool(object):
             name="footFeatClass",
             datatype="DEFeatureClass",
             parameterType="required",
-            direction="Output")
+            direction="Output",
+        )
 
         # 7th parameter
         param6 = arcpy.Parameter(
@@ -248,9 +271,10 @@ class Add_Shape_Attributes_Low_Tool(object):
             name="additionalOption",
             datatype="GPBoolean",
             parameterType="required",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = False
-        
+
         parameters = [param0, param1, param2, param3, param4, param5, param6]
         return parameters
 
@@ -262,7 +286,6 @@ class Add_Shape_Attributes_Low_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -273,7 +296,7 @@ class Add_Shape_Attributes_Low_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         inBathy = parameters[2].valueAsText
@@ -281,7 +304,7 @@ class Add_Shape_Attributes_Low_Tool(object):
         headFeatClass = parameters[4].valueAsText
         footFeatClass = parameters[5].valueAsText
         additionalOption = parameters[6].valueAsText
-        
+
         # calling the helper functions
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
@@ -294,85 +317,106 @@ class Add_Shape_Attributes_Low_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
                         inBathy = helper.convert_backslach_forwardslach(lyr.dataSource)
-        
-       # check that the input feature class is in a correct format
+
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the output head featureclass is in a correct format
         if headFeatClass.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output head featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output head featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output foot featureclass is in a correct format
         if footFeatClass.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output foot featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output foot featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")]        
-        env.workspace=workspaceName
+
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
-        
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
-        
+
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-        
+            helper.addIDField(inFeatClass, "featID")
+
         # calculate compactness attribute
         helper.calculateCompactness(inFeatClass)
         # calculate circularity, convexity and solidity attributes
         helper.calculateCircularity_Convexity_Solidity(inFeatClass)
         # calculate sinuosity, length to width ratio, width to depth ratio, and other shape attributes
-        helper.calculateSinuosity_LwR_WdR_Slopes(workspaceName,tempFolder,inFeatClass,inBathy,headFeatClass,footFeatClass,additionalOption)
+        helper.calculateSinuosity_LwR_WdR_Slopes(
+            workspaceName,
+            tempFolder,
+            inFeatClass,
+            inBathy,
+            headFeatClass,
+            footFeatClass,
+            additionalOption,
+        )
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
         arcpy.AddMessage("Compacted the geodatabase")
-  
 
         return
 
 
-class Add_Topographic_Attributes_High_Tool(object):
+class Add_Topographic_Attributes_High_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Topographic Attributes High Tool"
@@ -388,8 +432,8 @@ class Add_Topographic_Attributes_High_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
-
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -397,7 +441,8 @@ class Add_Topographic_Attributes_High_Tool(object):
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
 
         # third parameter
@@ -406,7 +451,8 @@ class Add_Topographic_Attributes_High_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -414,9 +460,9 @@ class Add_Topographic_Attributes_High_Tool(object):
             name="slopeRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")        
+            direction="Input",
+        )
 
-        
         parameters = [param0, param1, param2, param3]
         return parameters
 
@@ -428,7 +474,6 @@ class Add_Topographic_Attributes_High_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -439,32 +484,34 @@ class Add_Topographic_Attributes_High_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         inBathy = parameters[2].valueAsText
         inSlope = parameters[3].valueAsText
-   
+
         # calling the helper functions
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
         inBathy = helper.convert_backslach_forwardslach(inBathy)
-        inSlope = helper.convert_backslach_forwardslach(inSlope)      
-   
+        inSlope = helper.convert_backslach_forwardslach(inSlope)
+
         # if the input feature class is selected from a drop-down list, the inFeatClass does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
@@ -473,67 +520,88 @@ class Add_Topographic_Attributes_High_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inSlope.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inSlope == lyr.name:
-                        inSlope = helper.convert_backslach_forwardslach(lyr.dataSource) 
+                        inSlope = helper.convert_backslach_forwardslach(lyr.dataSource)
 
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input slope grid is in a correct format
         rasDesc1 = arcpy.Describe(inSlope)
         rasFormat1 = rasDesc1.format
-        if rasFormat1 != 'FGDBR':
-            messages.addErrorMessage("The input slope raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat1 != "FGDBR":
+            messages.addErrorMessage(
+                "The input slope raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input slope grid is in a projected coordinate system
         spatialReference = rasDesc1.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input slope grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input slope grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
         itemList = []
-        fieldList = ['minDepth','maxDepth','depthRange','meanDepth','stdDepth',
-                     'minGradient','maxGradient','gradientRange','meanGradient','stdGradient']
-        
+        fieldList = [
+            "minDepth",
+            "maxDepth",
+            "depthRange",
+            "meanDepth",
+            "stdDepth",
+            "minGradient",
+            "maxGradient",
+            "gradientRange",
+            "meanGradient",
+            "stdGradient",
+        ]
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
 
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-        
+            helper.addIDField(inFeatClass, "featID")
 
         # add new topographic fields
         for field in fieldList:
@@ -543,7 +611,9 @@ class Add_Topographic_Attributes_High_Tool(object):
             if field in field_names:
                 arcpy.AddMessage(field + " exists")
             else:
-                arcpy.AddField_management(inFeatClass,field,fieldType,fieldPrecision,fieldScale)
+                arcpy.AddField_management(
+                    inFeatClass, field, fieldType, fieldPrecision, fieldScale
+                )
 
         # zonal statistics
         zoneField = "featID"
@@ -551,80 +621,85 @@ class Add_Topographic_Attributes_High_Tool(object):
         outTab2 = "outTab2"
         itemList.append(outTab1)
         itemList.append(outTab2)
-        outZ1 = ZonalStatisticsAsTable(inFeatClass, zoneField, inBathy,outTab1, "DATA", "ALL")
-        outZ2 = ZonalStatisticsAsTable(inFeatClass, zoneField, inSlope,outTab2, "DATA", "ALL")
+        outZ1 = ZonalStatisticsAsTable(
+            inFeatClass, zoneField, inBathy, outTab1, "DATA", "ALL"
+        )
+        outZ2 = ZonalStatisticsAsTable(
+            inFeatClass, zoneField, inSlope, outTab2, "DATA", "ALL"
+        )
 
         # calculate these topographic fields
         field = "minDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MIN" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "MIN" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "maxDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MAX" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "MAX" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "depthRange"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "RANGE" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "RANGE" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "meanDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MEAN" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)        
+        expression = "!" + outTab1 + "." + "MEAN" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "stdDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "STD" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "STD" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "minGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MIN" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "MIN" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "maxGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MAX" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "MAX" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "gradientRange"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "RANGE" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "RANGE" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "meanGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MEAN" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)        
+        expression = "!" + outTab2 + "." + "MEAN" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "stdGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "STD" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "STD" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         arcpy.AddMessage("All attributes added")
         # delete intermediate files
-        helper.deleteDataItems(itemList)  
+        helper.deleteDataItems(itemList)
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
-        arcpy.AddMessage("Compacted the geodatabase")  
+        arcpy.AddMessage("Compacted the geodatabase")
 
         return
 
-class Add_Topographic_Attributes_Low_Tool(object):
+
+class Add_Topographic_Attributes_Low_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Topographic Attributes Low Tool"
@@ -640,8 +715,8 @@ class Add_Topographic_Attributes_Low_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
-
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -649,7 +724,8 @@ class Add_Topographic_Attributes_Low_Tool(object):
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
 
         # third parameter
@@ -658,7 +734,8 @@ class Add_Topographic_Attributes_Low_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -666,15 +743,17 @@ class Add_Topographic_Attributes_Low_Tool(object):
             name="slopeRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
-        
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="Input Head Features",
             name="headFeatClass",
             datatype="GPFeatureLayer",
             parameterType="required",
-            direction="Input")
+            direction="Input",
+        )
 
         # sixth parameter
         param5 = arcpy.Parameter(
@@ -682,8 +761,9 @@ class Add_Topographic_Attributes_Low_Tool(object):
             name="footFeatClass",
             datatype="GPFeatureLayer",
             parameterType="required",
-            direction="Input")
-        
+            direction="Input",
+        )
+
         parameters = [param0, param1, param2, param3, param4, param5]
         return parameters
 
@@ -695,7 +775,6 @@ class Add_Topographic_Attributes_Low_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -706,35 +785,37 @@ class Add_Topographic_Attributes_Low_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         inBathy = parameters[2].valueAsText
         inSlope = parameters[3].valueAsText
         headFeatClass = parameters[4].valueAsText
-        footFeatClass = parameters[5].valueAsText        
+        footFeatClass = parameters[5].valueAsText
 
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
         inBathy = helper.convert_backslach_forwardslach(inBathy)
-        inSlope = helper.convert_backslach_forwardslach(inSlope)       
+        inSlope = helper.convert_backslach_forwardslach(inSlope)
         headFeatClass = helper.convert_backslach_forwardslach(headFeatClass)
-        footFeatClass = helper.convert_backslach_forwardslach(footFeatClass)        
+        footFeatClass = helper.convert_backslach_forwardslach(footFeatClass)
 
         # if the input feature class is selected from a drop-down list, the inFeatClass does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
@@ -743,7 +824,7 @@ class Add_Topographic_Attributes_Low_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inSlope.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inSlope == lyr.name:
@@ -752,117 +833,164 @@ class Add_Topographic_Attributes_Low_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if headFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if headFeatClass == lyr.name:
-                        headFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        headFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input feature class is selected from a drop-down list, the inFeatClass does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if footFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if footFeatClass == lyr.name:
-                        footFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        footFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
 
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input slope grid is in a correct format
         rasDesc1 = arcpy.Describe(inSlope)
         rasFormat1 = rasDesc1.format
-        if rasFormat1 != 'FGDBR':
-            messages.addErrorMessage("The input slope raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat1 != "FGDBR":
+            messages.addErrorMessage(
+                "The input slope raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-       # check that the input head feature class is in a correct format
+        # check that the input head feature class is in a correct format
         vecDesc1 = arcpy.Describe(headFeatClass)
-        vecType1 = vecDesc1.dataType        
-        if (vecType1 != 'FeatureClass') or (headFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input head featureclass must be a feature class in a File GeoDatabase!")
+        vecType1 = vecDesc1.dataType
+        if (vecType1 != "FeatureClass") or (headFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input head featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-       # check that the input foot feature class is in a correct format
+        # check that the input foot feature class is in a correct format
         vecDesc2 = arcpy.Describe(footFeatClass)
-        vecType2 = vecDesc2.dataType        
-        if (vecType2 != 'FeatureClass') or (footFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input foot featureclass must be a feature class in a File GeoDatabase!")
+        vecType2 = vecDesc2.dataType
+        if (vecType2 != "FeatureClass") or (footFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input foot featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input slope grid is in a projected coordinate system
         spatialReference = rasDesc1.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input slope grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input slope grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input head featureclass is in a projected coordinate system
         spatialReference = vecDesc1.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input head featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input head featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input foot featureclass is in a projected coordinate system
         spatialReference = vecDesc2.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input foot featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input foot featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
         itemList = []
-        fieldList = ['headDepth','footDepth','head_foot_depthRange','head_foot_gradient','minDepth','maxDepth','depthRange','meanDepth','stdDepth',
-                     'minGradient','maxGradient','gradientRange','meanGradient','stdGradient']
-        
+        fieldList = [
+            "headDepth",
+            "footDepth",
+            "head_foot_depthRange",
+            "head_foot_gradient",
+            "minDepth",
+            "maxDepth",
+            "depthRange",
+            "meanDepth",
+            "stdDepth",
+            "minGradient",
+            "maxGradient",
+            "gradientRange",
+            "meanGradient",
+            "stdGradient",
+        ]
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
 
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-        
+            helper.addIDField(inFeatClass, "featID")
+
         # check the 'head_foot_length' field exists
-        if 'head_foot_length' not in field_names:
-            messages.addErrorMessage(inFeatClass + " does not have the head_foot_length attribute. Please use the Add_Shape_Attribute_Tool to calculate the attribute.")
+        if "head_foot_length" not in field_names:
+            messages.addErrorMessage(
+                inFeatClass
+                + " does not have the head_foot_length attribute. Please use the Add_Shape_Attribute_Tool to calculate the attribute."
+            )
             raise arcpy.ExecuteError
         # check the depth attributes field exist in the headFeatClass
         fields1 = arcpy.ListFields(headFeatClass)
         field_names1 = [f.name for f in fields1]
-        if ('depth' not in field_names1) | ('depth1' not in field_names1):
-            messages.addErrorMessage(headFeatClass + " does not have the required depth attributes. Please use the Add_Shape_Attribute_Tool to generate the head featureclass with the required depth attributes.")
+        if ("depth" not in field_names1) | ("depth1" not in field_names1):
+            messages.addErrorMessage(
+                headFeatClass
+                + " does not have the required depth attributes. Please use the Add_Shape_Attribute_Tool to generate the head featureclass with the required depth attributes."
+            )
             raise arcpy.ExecuteError
-        
+
         fields2 = arcpy.ListFields(footFeatClass)
         field_names2 = [f.name for f in fields2]
-        if ('depth' not in field_names2) | ('depth1' not in field_names2):
-            messages.addErrorMessage(footFeatClass + " does not have the required depth attributes. Please use the Add_Shape_Attribute_Tool to generate the foot featureclass with the required depth attributes.")
+        if ("depth" not in field_names2) | ("depth1" not in field_names2):
+            messages.addErrorMessage(
+                footFeatClass
+                + " does not have the required depth attributes. Please use the Add_Shape_Attribute_Tool to generate the foot featureclass with the required depth attributes."
+            )
             raise arcpy.ExecuteError
 
         # add new topographic fields
@@ -873,7 +1001,9 @@ class Add_Topographic_Attributes_Low_Tool(object):
             if field in field_names:
                 arcpy.AddMessage(field + " exists")
             else:
-                arcpy.AddField_management(inFeatClass,field,fieldType,fieldPrecision,fieldScale)
+                arcpy.AddField_management(
+                    inFeatClass, field, fieldType, fieldPrecision, fieldScale
+                )
 
         # zonal statistics
         zoneField = "featID"
@@ -881,147 +1011,153 @@ class Add_Topographic_Attributes_Low_Tool(object):
         outTab2 = "outTab2"
         itemList.append(outTab1)
         itemList.append(outTab2)
-        outZ1 = ZonalStatisticsAsTable(inFeatClass, zoneField, inBathy,outTab1, "DATA", "ALL")
-        outZ2 = ZonalStatisticsAsTable(inFeatClass, zoneField, inSlope,outTab2, "DATA", "ALL")
+        outZ1 = ZonalStatisticsAsTable(
+            inFeatClass, zoneField, inBathy, outTab1, "DATA", "ALL"
+        )
+        outZ2 = ZonalStatisticsAsTable(
+            inFeatClass, zoneField, inSlope, outTab2, "DATA", "ALL"
+        )
         # calculate these fields
         field = "minDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MIN" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "MIN" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "maxDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MAX" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "MAX" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "depthRange"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "RANGE" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "RANGE" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "meanDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "MEAN" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)        
+        expression = "!" + outTab1 + "." + "MEAN" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "stdDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab1 + "." + "STD" + "!"        
-        helper.addField(inFeatClass,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "STD" + "!"
+        helper.addField(inFeatClass, outTab1, field, inID, joinID, expression)
 
         field = "minGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MIN" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "MIN" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "maxGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MAX" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "MAX" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "gradientRange"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "RANGE" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "RANGE" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "meanGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "MEAN" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)        
+        expression = "!" + outTab2 + "." + "MEAN" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
         field = "stdGradient"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + outTab2 + "." + "STD" + "!"        
-        helper.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + outTab2 + "." + "STD" + "!"
+        helper.addField(inFeatClass, outTab2, field, inID, joinID, expression)
 
-        #spatial join
+        # spatial join
         joinFeat1 = "joinFeat1"
         itemList.append(joinFeat1)
-        arcpy.SpatialJoin_analysis(inFeatClass,headFeatClass,joinFeat1)
+        arcpy.SpatialJoin_analysis(inFeatClass, headFeatClass, joinFeat1)
 
         joinFeat2 = "joinFeat2"
         itemList.append(joinFeat2)
-        arcpy.SpatialJoin_analysis(inFeatClass,footFeatClass,joinFeat2)
+        arcpy.SpatialJoin_analysis(inFeatClass, footFeatClass, joinFeat2)
 
         # selection analysis
         selectFeat1 = "selectFeat1"
         itemList.append(selectFeat1)
         whereClause = '"depth" IS NULL'
-        arcpy.Select_analysis(joinFeat1,selectFeat1,whereClause)
+        arcpy.Select_analysis(joinFeat1, selectFeat1, whereClause)
 
         selectFeat2 = "selectFeat2"
         itemList.append(selectFeat2)
         whereClause = '"depth" IS NOT NULL'
-        arcpy.Select_analysis(joinFeat1,selectFeat2,whereClause)
+        arcpy.Select_analysis(joinFeat1, selectFeat2, whereClause)
         # if the depth is null, replace it with the depth1 field
-        arcpy.CalculateField_management(selectFeat1,"depth",'!depth1!',"PYTHON_9.3")
+        arcpy.CalculateField_management(selectFeat1, "depth", "!depth1!", "PYTHON_9.3")
         mergedFeat1 = "mergedFeat1"
         itemList.append(mergedFeat1)
-        mergedFeats = [selectFeat1,selectFeat2]
-        arcpy.Merge_management(mergedFeats,mergedFeat1)
+        mergedFeats = [selectFeat1, selectFeat2]
+        arcpy.Merge_management(mergedFeats, mergedFeat1)
 
         # selection analysis
         selectFeat3 = "selectFeat3"
         itemList.append(selectFeat3)
         whereClause = '"depth" IS NULL'
-        arcpy.Select_analysis(joinFeat2,selectFeat3,whereClause)
+        arcpy.Select_analysis(joinFeat2, selectFeat3, whereClause)
 
         selectFeat4 = "selectFeat4"
         itemList.append(selectFeat4)
         whereClause = '"depth" IS NOT NULL'
-        arcpy.Select_analysis(joinFeat2,selectFeat4,whereClause)
+        arcpy.Select_analysis(joinFeat2, selectFeat4, whereClause)
 
-        arcpy.CalculateField_management(selectFeat3,"depth",'!depth1!',"PYTHON_9.3")
+        arcpy.CalculateField_management(selectFeat3, "depth", "!depth1!", "PYTHON_9.3")
         mergedFeat2 = "mergedFeat2"
         itemList.append(mergedFeat2)
-        mergedFeats = [selectFeat3,selectFeat4]
-        arcpy.Merge_management(mergedFeats,mergedFeat2)
+        mergedFeats = [selectFeat3, selectFeat4]
+        arcpy.Merge_management(mergedFeats, mergedFeat2)
 
-        
         field = "headDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + mergedFeat1 + "." + "depth" + "!"        
-        helper.addField(inFeatClass,mergedFeat1,field,inID,joinID,expression)
+        expression = "!" + mergedFeat1 + "." + "depth" + "!"
+        helper.addField(inFeatClass, mergedFeat1, field, inID, joinID, expression)
 
         field = "footDepth"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + mergedFeat2 + "." + "depth" + "!"        
-        helper.addField(inFeatClass,mergedFeat2,field,inID,joinID,expression)
+        expression = "!" + mergedFeat2 + "." + "depth" + "!"
+        helper.addField(inFeatClass, mergedFeat2, field, inID, joinID, expression)
 
         field = "head_foot_depthRange"
         inID = "featID"
         joinID = "featID"
-        expression = "!headDepth! - !footDepth!"        
-        arcpy.CalculateField_management(inFeatClass,field,expression,"PYTHON_9.3")
+        expression = "!headDepth! - !footDepth!"
+        arcpy.CalculateField_management(inFeatClass, field, expression, "PYTHON_9.3")
 
         field = "head_foot_gradient"
         inID = "featID"
         joinID = "featID"
-        expression = 'math.degrees(math.atan(!head_foot_depthRange! / !head_foot_length!))'        
-        arcpy.CalculateField_management(inFeatClass,field,expression,"PYTHON_9.3")
+        expression = (
+            "math.degrees(math.atan(!head_foot_depthRange! / !head_foot_length!))"
+        )
+        arcpy.CalculateField_management(inFeatClass, field, expression, "PYTHON_9.3")
 
         arcpy.AddMessage("All attributes added")
 
-        helper.deleteDataItems(itemList)  
+        helper.deleteDataItems(itemList)
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
-        arcpy.AddMessage("Compacted the geodatabase")  
+        arcpy.AddMessage("Compacted the geodatabase")
 
         return
-    
-class Add_Profile_Attributes_High_Tool(object):
+
+
+class Add_Profile_Attributes_High_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Profile Attributes High Tool"
@@ -1037,7 +1173,8 @@ class Add_Profile_Attributes_High_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -1045,23 +1182,26 @@ class Add_Profile_Attributes_High_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         # third parameter
         param2 = arcpy.Parameter(
             displayName="Output Features",
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param2.parameterDependencies = [param0.name]
-        
+
         # fourth parameter
         param3 = arcpy.Parameter(
             displayName="Area Threshold",
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")        
+            direction="Input",
+        )
 
         # fifth parameter
         param4 = arcpy.Parameter(
@@ -1069,8 +1209,9 @@ class Add_Profile_Attributes_High_Tool(object):
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
-        
+            direction="Input",
+        )
+
         parameters = [param0, param1, param2, param3, param4]
         return parameters
 
@@ -1082,7 +1223,6 @@ class Add_Profile_Attributes_High_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -1094,16 +1234,15 @@ class Add_Profile_Attributes_High_Tool(object):
     def execute(self, parameters, messages):
         """The source code of the tool."""
 
-
         # the code below turns off theSettingwithCopyWarning related to pandas dataframe procesing which would cause arcpy to throw exceptions
-        #pd.set_option('mode.chained_assignment',None)
-        
+        # pd.set_option('mode.chained_assignment',None)
+
         inFeatClass = parameters[0].valueAsText
         inBathy = parameters[1].valueAsText
         outFeatClass = parameters[2].valueAsText
         areaThreshold = parameters[3].valueAsText
         tempFolder = parameters[4].valueAsText
-        
+
         # calling the helper functions
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
@@ -1113,99 +1252,129 @@ class Add_Profile_Attributes_High_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
                         inBathy = helper.convert_backslach_forwardslach(lyr.dataSource)
 
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
-
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
         # areaThreshold input has two components: the threshold value and the area unit
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        
+        areaUnit = areaThreshold.split(" ")[1]
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-        
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
 
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-        
+            helper.addIDField(inFeatClass, "featID")
+
         # check the 'LengthWidthRatio' field exists
-        if 'LengthWidthRatio' not in field_names:
-            messages.addErrorMessage("Error! The input features need to have the LengthWidthRatio attribute before the tool can run. Please use Add Shape Attribute Tool to calculate the attribute")
+        if "LengthWidthRatio" not in field_names:
+            messages.addErrorMessage(
+                "Error! The input features need to have the LengthWidthRatio attribute before the tool can run. Please use Add Shape Attribute Tool to calculate the attribute"
+            )
             raise arcpy.ExecuteError
-        
+
         # eight profile attributes to be added to the input feature
-        fieldList = ['profileShape','profileSymmetry','profileConcavity','profile_top_SlopeClass','profile_side_SlopeClass','profile_top_Depth','profileRelief','profileLength']    
+        fieldList = [
+            "profileShape",
+            "profileSymmetry",
+            "profileConcavity",
+            "profile_top_SlopeClass",
+            "profile_side_SlopeClass",
+            "profile_top_Depth",
+            "profileRelief",
+            "profileLength",
+        ]
         for field in fieldList:
             if field in field_names:
                 arcpy.AddMessage(field + " already exists and will be deleted")
-                arcpy.DeleteField_management(inFeatClass,field)
+                arcpy.DeleteField_management(inFeatClass, field)
 
-        
-                
-        itemList1 = [] 
+        itemList1 = []
         # expand inBathy
         # This is to ensure that the profile point(s) at the edge of bathymetry grid have depth values
         inFocal = inBathy + "_focal"
         itemList1.append(inFocal)
-        outFocalStat = FocalStatistics(inBathy, NbrRectangle(3,3,"CELL"),"MEAN","DATA")
+        outFocalStat = FocalStatistics(
+            inBathy, NbrRectangle(3, 3, "CELL"), "MEAN", "DATA"
+        )
         outFocalStat.save(inFocal)
         # mosaic to new raster
         mosaicBathy = "mosaicBathy"
         itemList1.append(mosaicBathy)
-        inputRasters = [inBathy,inFocal]  
-        arcpy.MosaicToNewRaster_management(inputRasters,workspaceName, mosaicBathy, inBathy, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
+        inputRasters = [inBathy, inFocal]
+        arcpy.MosaicToNewRaster_management(
+            inputRasters,
+            workspaceName,
+            mosaicBathy,
+            inBathy,
+            "32_BIT_FLOAT",
+            "#",
+            "1",
+            "FIRST",
+            "FIRST",
+        )
         arcpy.AddMessage("mosaic done")
         mosaicBathy = workspaceName + "/" + "mosaicBathy"
 
         mergeList = []
-        
+
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = helper.areaUnitConverter(areaUnit)
         areaThresholdValue = converter * float(areaThresholdValue)
@@ -1215,7 +1384,9 @@ class Add_Profile_Attributes_High_Tool(object):
         # generate bounding rectangle
         MbrFeatClass = "bounding_rectangle"
         itemList1.append(MbrFeatClass)
-        arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         arcpy.AddMessage("bouning rectangle generated")
         noFeat = int(arcpy.GetCount_management(inFeatClass).getOutput(0))
         noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
@@ -1224,17 +1395,45 @@ class Add_Profile_Attributes_High_Tool(object):
         # Number of features in the bounding rectangle is expected to be the same as in the input featureclass
         # if not, regenerate the bounding rectanlge up to three times
         if noRectangle < noFeat:
-            arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+            arcpy.MinimumBoundingGeometry_management(
+                inFeatClass,
+                MbrFeatClass,
+                "RECTANGLE_BY_WIDTH",
+                "NONE",
+                "",
+                "MBG_FIELDS",
+            )
             noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
             if noRectangle < noFeat:
-                arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+                arcpy.MinimumBoundingGeometry_management(
+                    inFeatClass,
+                    MbrFeatClass,
+                    "RECTANGLE_BY_WIDTH",
+                    "NONE",
+                    "",
+                    "MBG_FIELDS",
+                )
                 noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
                 if noRectangle < noFeat:
-                    arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
-                    noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
+                    arcpy.MinimumBoundingGeometry_management(
+                        inFeatClass,
+                        MbrFeatClass,
+                        "RECTANGLE_BY_WIDTH",
+                        "NONE",
+                        "",
+                        "MBG_FIELDS",
+                    )
+                    noRectangle = int(
+                        arcpy.GetCount_management(MbrFeatClass).getOutput(0)
+                    )
                     if noRectangle < noFeat:
-                        arcpy.AddMessage("noRectangle: " + str(noRectangle) + " doesnot equal to noFeat: " + str(noFeat))
-        
+                        arcpy.AddMessage(
+                            "noRectangle: "
+                            + str(noRectangle)
+                            + " doesnot equal to noFeat: "
+                            + str(noFeat)
+                        )
+
         # loop through each input feature
         cursor = arcpy.SearchCursor(inFeatClass)
         # to catch the failed feature(s)
@@ -1242,8 +1441,10 @@ class Add_Profile_Attributes_High_Tool(object):
         k = 1
         for row in cursor:
             # only do this every 100 iterations
-            if k%100 == 1:
-                arcpy.Compact_management(workspaceName) # compact the geodatabase to reduce its size and potentially improve the performance
+            if k % 100 == 1:
+                arcpy.Compact_management(
+                    workspaceName
+                )  # compact the geodatabase to reduce its size and potentially improve the performance
                 arcpy.AddMessage("Compacted the geodatabase")
             try:
                 itemList = []
@@ -1252,47 +1453,57 @@ class Add_Profile_Attributes_High_Tool(object):
 
                 LwR = row.getValue("LengthWidthRatio")
                 area = row.getValue("Shape_Area")
-                arcpy.AddMessage('area: ' + str(area))
+                arcpy.AddMessage("area: " + str(area))
                 whereClause = '"featID" = ' + str(featID)
                 inFeat = workspaceName + "/" + "inFeat_" + str(featID)
                 mergeList.append(inFeat)
-                
+
                 # select the feature
-                arcpy.Select_analysis(inFeatClass,inFeat,whereClause)
+                arcpy.Select_analysis(inFeatClass, inFeat, whereClause)
 
                 boundFeat = workspaceName + "/" + "boundFeat_" + str(featID)
                 itemList.append(boundFeat)
-                
+
                 # select the feature
-                arcpy.Select_analysis(MbrFeatClass,boundFeat,whereClause)
-                
+                arcpy.Select_analysis(MbrFeatClass, boundFeat, whereClause)
+
                 profilePointFC = workspaceName + "/" + "profilePointFC"
                 itemList.append(profilePointFC)
 
                 # depending on the following criteria, creating different profiles
-                if area < areaThresholdValue: # for a smaller polygon feature, create only one profile. This would save time
+                if (
+                    area < areaThresholdValue
+                ):  # for a smaller polygon feature, create only one profile. This would save time
                     time1 = datetime.now()
-                    helper.create_profiles3(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()       
+                    helper.create_profiles3(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profile3.")
-                elif LwR <= 5.0: # for a polygon feature that is not elongated, create five profiles passing through the polygon centre
+                    arcpy.AddMessage("took " + str(diff) + " to create profile3.")
+                elif (
+                    LwR <= 5.0
+                ):  # for a polygon feature that is not elongated, create five profiles passing through the polygon centre
                     time1 = datetime.now()
-                    helper.create_profiles1(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()                        
+                    helper.create_profiles1(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profiles1.")                
-                else: # for an elongated polygon feature, create five profiles across the long axis of the polygon
+                    arcpy.AddMessage("took " + str(diff) + " to create profiles1.")
+                else:  # for an elongated polygon feature, create five profiles across the long axis of the polygon
                     time1 = datetime.now()
-                    helper.create_profiles2(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()                        
+                    helper.create_profiles2(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profiles2.")
-                    
+                    arcpy.AddMessage("took " + str(diff) + " to create profiles2.")
+
                 # extract depth values to profile points
                 profilePointFC1 = workspaceName + "/" + "profilePointFC1"
                 itemList.append(profilePointFC1)
-                ExtractValuesToPoints(profilePointFC,mosaicBathy,profilePointFC1)
+                ExtractValuesToPoints(profilePointFC, mosaicBathy, profilePointFC1)
                 arcpy.AddMessage("extract depth values done")
                 # Add x and y
                 arcpy.AddXY_management(profilePointFC1)
@@ -1304,13 +1515,13 @@ class Add_Profile_Attributes_High_Tool(object):
                 schemaFile = tempFolder + "/" + "schema.ini"
                 if os.path.isfile(schemaFile):
                     os.remove(schemaFile)
-                    
-                arcpy.CopyRows_management(profilePointFC1,outCSV)
+
+                arcpy.CopyRows_management(profilePointFC1, outCSV)
                 arcpy.AddMessage(outCSV + " is generated")
                 # read in the csv file as pandas dataframe
-                points = pd.read_csv(outCSV,sep=",",header=0)
-                points.set_index('OBJECTID',inplace=True)
-                
+                points = pd.read_csv(outCSV, sep=",", header=0)
+                points.set_index("OBJECTID", inplace=True)
+
                 # calculate profile attributes
                 profileIDList = np.unique(points.profileID)
                 shapeList = []
@@ -1322,20 +1533,27 @@ class Add_Profile_Attributes_High_Tool(object):
                 heightList = []
                 lengthList = []
                 # loop through each profile for the polygon feature
-                for profileID in profileIDList:                
+                for profileID in profileIDList:
                     pointsT = points.loc[points.profileID == profileID].copy()
-                    depthCol = 'RASTERVALU'
+                    depthCol = "RASTERVALU"
                     if pointsT.index.size > 10:
                         gap = 4
-                    else:            
+                    else:
                         gap = 3
                     # calling the 'calculate_profile_attributes_high' function
-                    shape,symmetry,concave,topSlopeClass,sideSlopeClass,topDepth,height,length = helper.calculate_profile_attributes_high(pointsT,
-                                                                                                                          depthCol,
-                                                                                                                          'POINT_X',
-                                                                                                                         'POINT_Y',
-                                                                                                                            gap)
-                    # append the profile attributes to the lists 
+                    (
+                        shape,
+                        symmetry,
+                        concave,
+                        topSlopeClass,
+                        sideSlopeClass,
+                        topDepth,
+                        height,
+                        length,
+                    ) = helper.calculate_profile_attributes_high(
+                        pointsT, depthCol, "POINT_X", "POINT_Y", gap
+                    )
+                    # append the profile attributes to the lists
                     shapeList.append(shape)
                     symmetryList.append(symmetry)
                     concaveList.append(concave)
@@ -1344,18 +1562,18 @@ class Add_Profile_Attributes_High_Tool(object):
                     topDepthList.append(topDepth)
                     heightList.append(height)
                     lengthList.append(length)
-                
+
                 valueList = []
                 # for a polygon feature with five profiles, join all attribute values together as a string
-                shape = ','.join(shapeList)
-                symmetry = ','.join(symmetryList)
-                concave = ','.join(concaveList)
-                topSlopeClass = ','.join(topSlopeClassList)
-                sideSlopeClass = ','.join(sideSlopeClassList)
-                topDepth = ','.join(topDepthList)
-                height = ','.join(heightList)
-                length = ','.join(lengthList)
-                
+                shape = ",".join(shapeList)
+                symmetry = ",".join(symmetryList)
+                concave = ",".join(concaveList)
+                topSlopeClass = ",".join(topSlopeClassList)
+                sideSlopeClass = ",".join(sideSlopeClassList)
+                topDepth = ",".join(topDepthList)
+                height = ",".join(heightList)
+                length = ",".join(lengthList)
+
                 valueList.append(shape)
                 valueList.append(symmetry)
                 valueList.append(concave)
@@ -1366,8 +1584,7 @@ class Add_Profile_Attributes_High_Tool(object):
                 valueList.append(length)
                 arcpy.AddMessage(valueList)
                 arcpy.AddMessage("profile attributes calculated")
-      
-                
+
                 for field in fieldList:
                     fieldType = "TEXT"
                     fieldLength = 200
@@ -1376,66 +1593,70 @@ class Add_Profile_Attributes_High_Tool(object):
                     if field in field_names:
                         arcpy.AddMessage(field + " exists")
                     else:
-                        arcpy.AddField_management(inFeat,field,fieldType,field_length=fieldLength)
-                 
+                        arcpy.AddField_management(
+                            inFeat, field, fieldType, field_length=fieldLength
+                        )
 
                 arcpy.AddMessage("profile fields added")
-             
+
                 # calculate fields
                 i = 0
                 for field in fieldList:
                     # calculate string to a text field, the string must be enclosed by double quote
                     expression = '"' + valueList[i] + '"'
-                    arcpy.CalculateField_management(inFeat, field, expression, "PYTHON_9.3")
+                    arcpy.CalculateField_management(
+                        inFeat, field, expression, "PYTHON_9.3"
+                    )
                     i += 1
-                    
+
                 arcpy.AddMessage("profile fields calculated")
-                
+
                 # delete intermediate data
                 helper.deleteDataItems(itemList)
                 arcpy.AddMessage("intermediate data deleted")
-            except:                
+            except:
                 arcpy.AddMessage("failed on " + str(featID))
                 failedIDList.append(featID)
                 continue
-            k += 1        
-
+            k += 1
 
         del cursor, row
-                                                                                                                                      
+
         # merge all individual features together
         mergedFeat = "mergedFeat"
-        arcpy.Merge_management(mergeList,mergedFeat)
+        arcpy.Merge_management(mergeList, mergedFeat)
         arcpy.AddMessage("merged all done")
 
         helper.deleteDataItems(mergeList)
         helper.deleteDataItems(itemList1)
         arcpy.AddMessage("data deletion done")
-        
+
         # transfer the field values to inFeatClass
-        
-        for field in fieldList:            
+
+        for field in fieldList:
             inID = "featID"
             joinID = "featID"
-            expression = "!" + mergedFeat + "." + field + "!"        
-            helper.addTextField(inFeatClass,mergedFeat,field,inID,joinID,expression)
+            expression = "!" + mergedFeat + "." + field + "!"
+            helper.addTextField(
+                inFeatClass, mergedFeat, field, inID, joinID, expression
+            )
 
-            
         arcpy.AddMessage("Profile attributes added and calculated")
 
         arcpy.Delete_management(mergedFeat)
 
-        if len(failedIDList) > 0: 
+        if len(failedIDList) > 0:
             arcpy.AddMessage("Failed on the following featID(s):" + str(failedIDList))
             arcpy.AddMessage("You may want to re-run only these features")
-  
+
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
         arcpy.AddMessage("Compacted the geodatabase")
-        
+
         return
 
-class Add_Profile_Attributes_Low_Tool(object):
+
+class Add_Profile_Attributes_Low_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Add Profile Attributes Low Tool"
@@ -1451,7 +1672,8 @@ class Add_Profile_Attributes_Low_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -1459,14 +1681,16 @@ class Add_Profile_Attributes_Low_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         # third parameter
         param2 = arcpy.Parameter(
             displayName="Output Features",
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param2.parameterDependencies = [param0.name]
 
         # fourth parameter
@@ -1475,7 +1699,8 @@ class Add_Profile_Attributes_Low_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # fourth parameter
         param4 = arcpy.Parameter(
@@ -1483,9 +1708,10 @@ class Add_Profile_Attributes_Low_Tool(object):
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")
-        
-        parameters = [param0, param1, param2, param3,param4]
+            direction="Input",
+        )
+
+        parameters = [param0, param1, param2, param3, param4]
         return parameters
 
     def isLicensed(self):
@@ -1496,7 +1722,6 @@ class Add_Profile_Attributes_Low_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -1508,16 +1733,15 @@ class Add_Profile_Attributes_Low_Tool(object):
     def execute(self, parameters, messages):
         """The source code of the tool."""
 
- 
         # the code below turns off theSettingwithCopyWarning related to pandas dataframe procesing which would cause arcpy to throw exceptions
-        #pd.set_option('mode.chained_assignment',None)
-                                                                                                                                      
+        # pd.set_option('mode.chained_assignment',None)
+
         inFeatClass = parameters[0].valueAsText
         inBathy = parameters[1].valueAsText
         outFeatClass = parameters[2].valueAsText
         areaThreshold = parameters[3].valueAsText
         tempFolder = parameters[4].valueAsText
-        
+
         # calling the helper functions
         helper = helpers()
         inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
@@ -1527,95 +1751,127 @@ class Add_Profile_Attributes_Low_Tool(object):
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
         # if the input bathymetry raster is selected from a drop-down list, the inBathy does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inBathy.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if inBathy == lyr.name:
                         inBathy = helper.convert_backslach_forwardslach(lyr.dataSource)
 
-       # check that the input feature class is in a correct format
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(inBathy)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input featureclass is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
 
-
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        
+        areaUnit = areaThreshold.split(" ")[1]
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-        
+
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
 
         # check the 'featID' field exists
         # if not, add and calculate it
-        if 'featID' not in field_names:
+        if "featID" not in field_names:
             arcpy.AddMessage("Adding an unique featID...")
-            helper.addIDField(inFeatClass,'featID')
-                                                                                                                                      
-        # checck the 'LengthWidthRatio' field exists                                                                                                                              
-        if 'LengthWidthRatio' not in field_names:
-            messages.addErrorMessage("Error! The input features need to have the LengthWidthRatio attribute before the tool can be run. Please use Add Shape Attribute Tool to calculate the attribute")
-            raise arcpy.ExecuteError                                                                                                                                      
+            helper.addIDField(inFeatClass, "featID")
+
+        # checck the 'LengthWidthRatio' field exists
+        if "LengthWidthRatio" not in field_names:
+            messages.addErrorMessage(
+                "Error! The input features need to have the LengthWidthRatio attribute before the tool can be run. Please use Add Shape Attribute Tool to calculate the attribute"
+            )
+            raise arcpy.ExecuteError
 
         # eight profile attributes to be added to the input feature
-        fieldList = ['profileShape','profileSymmetry','profileConcavity','profile_bottom_SlopeClass','profile_side_SlopeClass','profile_bottom_Depth','profileRelief','profileLength']        
+        fieldList = [
+            "profileShape",
+            "profileSymmetry",
+            "profileConcavity",
+            "profile_bottom_SlopeClass",
+            "profile_side_SlopeClass",
+            "profile_bottom_Depth",
+            "profileRelief",
+            "profileLength",
+        ]
         for field in fieldList:
             if field in field_names:
                 arcpy.AddMessage(field + " already exists and will be deleted")
-                arcpy.DeleteField_management(inFeatClass,field)
-                
-        itemList1 = [] 
+                arcpy.DeleteField_management(inFeatClass, field)
+
+        itemList1 = []
         # expand inBathy
-        # This is to ensure that the profile point(s) at the edge of bathymetry grid have depth values                                                                                                                                      
+        # This is to ensure that the profile point(s) at the edge of bathymetry grid have depth values
         inFocal = inBathy + "_focal"
         itemList1.append(inFocal)
-        outFocalStat = FocalStatistics(inBathy, NbrRectangle(3,3,"CELL"),"MEAN","DATA")
+        outFocalStat = FocalStatistics(
+            inBathy, NbrRectangle(3, 3, "CELL"), "MEAN", "DATA"
+        )
         outFocalStat.save(inFocal)
         # mosaic to new raster
         mosaicBathy = "mosaicBathy"
         itemList1.append(mosaicBathy)
-        inputRasters = [inBathy,inFocal]  
-        arcpy.MosaicToNewRaster_management(inputRasters,workspaceName, mosaicBathy, inBathy, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
+        inputRasters = [inBathy, inFocal]
+        arcpy.MosaicToNewRaster_management(
+            inputRasters,
+            workspaceName,
+            mosaicBathy,
+            inBathy,
+            "32_BIT_FLOAT",
+            "#",
+            "1",
+            "FIRST",
+            "FIRST",
+        )
         arcpy.AddMessage("mosaic done")
         mosaicBathy = workspaceName + "/" + "mosaicBathy"
-        
+
         mergeList = []
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = helper.areaUnitConverter(areaUnit)
@@ -1626,7 +1882,9 @@ class Add_Profile_Attributes_Low_Tool(object):
         # generate bounding rectangle
         MbrFeatClass = "bounding_rectangle"
         itemList1.append(MbrFeatClass)
-        arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         noFeat = int(arcpy.GetCount_management(inFeatClass).getOutput(0))
         noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
         arcpy.AddMessage("noFeat: " + str(noFeat))
@@ -1634,24 +1892,54 @@ class Add_Profile_Attributes_Low_Tool(object):
         # Number of features in the bounding rectangle is expected to be the same as in the input featureclass
         # if not, regenerate the bounding rectanlge up to three times
         if noRectangle < noFeat:
-            arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+            arcpy.MinimumBoundingGeometry_management(
+                inFeatClass,
+                MbrFeatClass,
+                "RECTANGLE_BY_WIDTH",
+                "NONE",
+                "",
+                "MBG_FIELDS",
+            )
             noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
             if noRectangle < noFeat:
-                arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+                arcpy.MinimumBoundingGeometry_management(
+                    inFeatClass,
+                    MbrFeatClass,
+                    "RECTANGLE_BY_WIDTH",
+                    "NONE",
+                    "",
+                    "MBG_FIELDS",
+                )
                 noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
                 if noRectangle < noFeat:
-                    arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
-                    noRectangle = int(arcpy.GetCount_management(MbrFeatClass).getOutput(0))
+                    arcpy.MinimumBoundingGeometry_management(
+                        inFeatClass,
+                        MbrFeatClass,
+                        "RECTANGLE_BY_WIDTH",
+                        "NONE",
+                        "",
+                        "MBG_FIELDS",
+                    )
+                    noRectangle = int(
+                        arcpy.GetCount_management(MbrFeatClass).getOutput(0)
+                    )
                     if noRectangle < noFeat:
-                        arcpy.AddMessage("noRectangle: " + str(noRectangle) + " doesnot equal to noFeat: " + str(noFeat))        
+                        arcpy.AddMessage(
+                            "noRectangle: "
+                            + str(noRectangle)
+                            + " doesnot equal to noFeat: "
+                            + str(noFeat)
+                        )
         cursor = arcpy.SearchCursor(inFeatClass)
         failedIDList = []
         # loop through each feature
         k = 1
         for row in cursor:
             # only do this every 100 iterations
-            if k%100 == 1:
-                arcpy.Compact_management(workspaceName) # compact the geodatabase to reduce its size and potentially improve the performance
+            if k % 100 == 1:
+                arcpy.Compact_management(
+                    workspaceName
+                )  # compact the geodatabase to reduce its size and potentially improve the performance
                 arcpy.AddMessage("Compacted the geodatabase")
             try:
                 itemList = []
@@ -1659,48 +1947,57 @@ class Add_Profile_Attributes_Low_Tool(object):
                 arcpy.AddMessage("working on feature: " + str(featID))
                 LwR = row.getValue("LengthWidthRatio")
                 area = row.getValue("Shape_Area")
-                arcpy.AddMessage('area: ' + str(area))
+                arcpy.AddMessage("area: " + str(area))
                 whereClause = '"featID" = ' + str(featID)
                 inFeat = workspaceName + "/" + "inFeat_" + str(featID)
                 mergeList.append(inFeat)
-                
+
                 # select the feature
-                arcpy.Select_analysis(inFeatClass,inFeat,whereClause)
-                
+                arcpy.Select_analysis(inFeatClass, inFeat, whereClause)
+
                 boundFeat = workspaceName + "/" + "boundFeat_" + str(featID)
                 itemList.append(boundFeat)
-                
+
                 # select the feature
-                arcpy.Select_analysis(MbrFeatClass,boundFeat,whereClause)
-                
+                arcpy.Select_analysis(MbrFeatClass, boundFeat, whereClause)
+
                 profilePointFC = workspaceName + "/" + "profilePointFC"
                 itemList.append(profilePointFC)
 
                 # depending on the following criteria, creating different profiles
-                if area < areaThresholdValue: # for a smaller polygon feature, create only one profile. This would save time
+                if (
+                    area < areaThresholdValue
+                ):  # for a smaller polygon feature, create only one profile. This would save time
                     time1 = datetime.now()
-                    helper.create_profiles3(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()       
+                    helper.create_profiles3(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profile3.")
-                elif LwR <= 5.0: # for a polygon feature that is not elongated, create five profiles passing through the polygon centre
+                    arcpy.AddMessage("took " + str(diff) + " to create profile3.")
+                elif (
+                    LwR <= 5.0
+                ):  # for a polygon feature that is not elongated, create five profiles passing through the polygon centre
                     time1 = datetime.now()
-                    helper.create_profiles1(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()       
+                    helper.create_profiles1(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profile1.")
-                else: # for an elongated polygon feature, create five profiles across the long axis of the polygon
+                    arcpy.AddMessage("took " + str(diff) + " to create profile1.")
+                else:  # for an elongated polygon feature, create five profiles across the long axis of the polygon
                     time1 = datetime.now()
-                    helper.create_profiles2(inFeat,boundFeat,profilePointFC,tempFolder)
-                    time2 = datetime.now()       
+                    helper.create_profiles2(
+                        inFeat, boundFeat, profilePointFC, tempFolder
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to create profile2.")
-
+                    arcpy.AddMessage("took " + str(diff) + " to create profile2.")
 
                 # extract depth values to profile points
                 profilePointFC1 = workspaceName + "/" + "profilePointFC1"
                 itemList.append(profilePointFC1)
-                ExtractValuesToPoints(profilePointFC,mosaicBathy,profilePointFC1)
+                ExtractValuesToPoints(profilePointFC, mosaicBathy, profilePointFC1)
                 arcpy.AddMessage("extract depth values done")
                 # Add x and y
                 arcpy.AddXY_management(profilePointFC1)
@@ -1712,12 +2009,12 @@ class Add_Profile_Attributes_Low_Tool(object):
                 schemaFile = tempFolder + "/" + "schema.ini"
                 if os.path.isfile(schemaFile):
                     os.remove(schemaFile)
-                    
-                arcpy.CopyRows_management(profilePointFC1,outCSV)
+
+                arcpy.CopyRows_management(profilePointFC1, outCSV)
                 arcpy.AddMessage(outCSV + " is generated")
                 # read in the csv file as pandas dataframe
-                points = pd.read_csv(outCSV,sep=",",header=0)
-                points.set_index('OBJECTID',inplace=True)
+                points = pd.read_csv(outCSV, sep=",", header=0)
+                points.set_index("OBJECTID", inplace=True)
                 # calculate profile attributes
 
                 profileIDList = np.unique(points.profileID)
@@ -1731,19 +2028,26 @@ class Add_Profile_Attributes_Low_Tool(object):
                 lengthList = []
                 # loop through each profile
                 for profileID in profileIDList:
-                    
+
                     pointsT = points.loc[points.profileID == profileID].copy()
-                    depthCol = 'RASTERVALU'
+                    depthCol = "RASTERVALU"
                     if pointsT.index.size > 10:
                         gap = 4
-                    else:            
+                    else:
                         gap = 3
                     # calling the 'calculate_profile_attributes_low' helper function
-                    shape,symmetry,concave,bottomSlopeClass,sideSlopeClass,bottomDepth,height,length = helper.calculate_profile_attributes_low(pointsT,
-                                                                                                                          depthCol,
-                                                                                                                          'POINT_X',
-                                                                                                                         'POINT_Y',
-                                                                                                                             gap)
+                    (
+                        shape,
+                        symmetry,
+                        concave,
+                        bottomSlopeClass,
+                        sideSlopeClass,
+                        bottomDepth,
+                        height,
+                        length,
+                    ) = helper.calculate_profile_attributes_low(
+                        pointsT, depthCol, "POINT_X", "POINT_Y", gap
+                    )
                     shapeList.append(shape)
                     symmetryList.append(symmetry)
                     concaveList.append(concave)
@@ -1752,16 +2056,16 @@ class Add_Profile_Attributes_Low_Tool(object):
                     bottomDepthList.append(bottomDepth)
                     heightList.append(height)
                     lengthList.append(length)
-                
+
                 valueList = []
-                shape = ','.join(shapeList)
-                symmetry = ','.join(symmetryList)
-                concave = ','.join(concaveList)
-                bottomSlopeClass = ','.join(bottomSlopeClassList)
-                sideSlopeClass = ','.join(sideSlopeClassList)
-                bottomDepth = ','.join(bottomDepthList)
-                height = ','.join(heightList)
-                length = ','.join(lengthList)
+                shape = ",".join(shapeList)
+                symmetry = ",".join(symmetryList)
+                concave = ",".join(concaveList)
+                bottomSlopeClass = ",".join(bottomSlopeClassList)
+                sideSlopeClass = ",".join(sideSlopeClassList)
+                bottomDepth = ",".join(bottomDepthList)
+                height = ",".join(heightList)
+                length = ",".join(lengthList)
                 valueList.append(shape)
                 valueList.append(symmetry)
                 valueList.append(concave)
@@ -1771,7 +2075,6 @@ class Add_Profile_Attributes_Low_Tool(object):
                 valueList.append(height)
                 valueList.append(length)
                 arcpy.AddMessage("profile attributes calculated")
-     
 
                 for field in fieldList:
                     fieldType = "TEXT"
@@ -1781,25 +2084,28 @@ class Add_Profile_Attributes_Low_Tool(object):
                     if field in field_names:
                         arcpy.AddMessage(field + " exists")
                     else:
-                        arcpy.AddField_management(inFeat,field,fieldType,field_length=fieldLength)                 
+                        arcpy.AddField_management(
+                            inFeat, field, fieldType, field_length=fieldLength
+                        )
 
-                
                 arcpy.AddMessage("profile fields added")
-             
+
                 # calculate fields
                 i = 0
                 for field in fieldList:
                     # calculate string to a text field, the string must be enclosed by double quote
                     expression = '"' + valueList[i] + '"'
-                    arcpy.CalculateField_management(inFeat, field, expression, "PYTHON_9.3")
+                    arcpy.CalculateField_management(
+                        inFeat, field, expression, "PYTHON_9.3"
+                    )
                     i += 1
 
                 arcpy.AddMessage("profile fields calculated")
-                
+
                 # delete intermediate data
                 helper.deleteDataItems(itemList)
                 arcpy.AddMessage("intermediate data deleted")
-        
+
             except:
                 arcpy.AddMessage("failed on " + str(featID))
                 failedIDList.append(featID)
@@ -1809,44 +2115,47 @@ class Add_Profile_Attributes_Low_Tool(object):
         del cursor, row
         # merge all individual features together
         mergedFeat = "mergedFeat"
-        arcpy.Merge_management(mergeList,mergedFeat)
+        arcpy.Merge_management(mergeList, mergedFeat)
         arcpy.AddMessage("merged all done")
-        
+
         helper.deleteDataItems(itemList1)
         helper.deleteDataItems(mergeList)
         arcpy.AddMessage("data deletion done")
-        
+
         # transfer the field values to inFeatClass
-        
-        for field in fieldList:            
+
+        for field in fieldList:
             inID = "featID"
             joinID = "featID"
-            expression = "!" + mergedFeat + "." + field + "!"        
-            helper.addTextField(inFeatClass,mergedFeat,field,inID,joinID,expression)
+            expression = "!" + mergedFeat + "." + field + "!"
+            helper.addTextField(
+                inFeatClass, mergedFeat, field, inID, joinID, expression
+            )
 
         arcpy.AddMessage("Profile attributes added and calculated")
 
         arcpy.Delete_management(mergedFeat)
 
-        if len(failedIDList) > 0: 
+        if len(failedIDList) > 0:
             arcpy.AddMessage("Failed on the following featID(s):" + str(failedIDList))
             arcpy.AddMessage("You may want to re-run only these features")
-          
+
         # compact the geodatabase to reduce its size
         arcpy.Compact_management(workspaceName)
         arcpy.AddMessage("Compacted the geodatabase")
-        
+
         return
 
-# All the helper functions are defined here                                                                    
-class helpers(object):
+
+# All the helper functions are defined here
+class helpers:
     # This function splits each polygon in the featureclass into mutiple sub-polygons along its long axis
-    def splitPolygon(self,workspace,inFeatClass,MbrFeatClass,splitFeatClass):
+    def splitPolygon(self, workspace, inFeatClass, MbrFeatClass, splitFeatClass):
         # workspace: location of workspace
         # inFeatClass: input Bathymetric High (Low) features
         # MbrFeatClass: input bounding recentagle featureclass
         # splitFeatClass: output featureclass containing the splitted features
-        
+
         mergeList = []
         itemList = []
         inFeat = workspace + "/" + "selection"
@@ -1855,13 +2164,13 @@ class helpers(object):
         itemList.append(inFeat)
         MbrPoints = workspace + "/" + "bounding_rectangle_points"
         itemList.append(MbrPoints)
-        fishnetFeat = workspace + '/' + 'fishnet'
-        itemList.append(fishnetFeat)          
-        # loop through each polygon    
+        fishnetFeat = workspace + "/" + "fishnet"
+        itemList.append(fishnetFeat)
+        # loop through each polygon
         cursor1 = arcpy.SearchCursor(inFeatClass)
         i = 1
         for row1 in cursor1:
-            if i%100 == 1:
+            if i % 100 == 1:
                 arcpy.Compact_management(workspace)
                 arcpy.AddMessage("Compacted the geodatabase")
             time1 = datetime.now()
@@ -1872,12 +2181,12 @@ class helpers(object):
             whereClause = '"featID" = ' + str(featID)
             arcpy.AddMessage("working on featID: " + str(featID))
             # select one polygon and its bounding polygon
-            arcpy.Select_analysis(inFeatClass,inFeat,whereClause)
-            arcpy.Select_analysis(workspace + "/" + MbrFeatClass,MbrFeat,whereClause)
+            arcpy.Select_analysis(inFeatClass, inFeat, whereClause)
+            arcpy.Select_analysis(workspace + "/" + MbrFeatClass, MbrFeat, whereClause)
             arcpy.AddMessage("selection done")
-            
+
             # convert bounding rectangle to points
-            arcpy.FeatureVerticesToPoints_management(MbrFeat,MbrPoints,"ALL")
+            arcpy.FeatureVerticesToPoints_management(MbrFeat, MbrPoints, "ALL")
             arcpy.AddMessage("bounding to points done")
             # add x and y
             arcpy.AddXY_management(MbrPoints)
@@ -1899,11 +2208,11 @@ class helpers(object):
             # Set coordinate system of the output fishnet as the input dataset
             env.outputCoordinateSystem = arcpy.Describe(MbrFeat).spatialReference
             # Set the origin of the fishnet
-            originCoordinate = str(start_x) + ' ' + str(start_y)            
+            originCoordinate = str(start_x) + " " + str(start_y)
             # Set the orientation
-            yAxisCoordinate = str(end_x) + ' ' + str(end_y)
-            # Set the number of rows and columns together with origin and opposite corner 
-            # determine the size of each cell (sub-polygon) based on the length of bounding recentagle (unit: metre) 
+            yAxisCoordinate = str(end_x) + " " + str(end_y)
+            # Set the number of rows and columns together with origin and opposite corner
+            # determine the size of each cell (sub-polygon) based on the length of bounding recentagle (unit: metre)
             if MbrL > 10000:
                 numRows = int(MbrL / 200) + 1
             elif MbrL > 1000:
@@ -1917,41 +2226,53 @@ class helpers(object):
             cellSizeHeight = MbrL / numRows
             numColumns = 1
 
-            oppositeCoorner = '#'
-            # Create a point label feature class 
-            labels = 'NO_LABELS'
+            oppositeCoorner = "#"
+            # Create a point label feature class
+            labels = "NO_LABELS"
             # Extent is set by origin and opposite corner - no need to use a template fc
-            templateExtent = '#'
+            templateExtent = "#"
             # Each output cell will be a polygon
-            geometryType = 'POLYGON'
-            arcpy.CreateFishnet_management(fishnetFeat, originCoordinate, yAxisCoordinate, cellSizeWidth,
-                                           cellSizeHeight, numRows, numColumns, oppositeCoorner, labels, templateExtent, geometryType)
+            geometryType = "POLYGON"
+            arcpy.CreateFishnet_management(
+                fishnetFeat,
+                originCoordinate,
+                yAxisCoordinate,
+                cellSizeWidth,
+                cellSizeHeight,
+                numRows,
+                numColumns,
+                oppositeCoorner,
+                labels,
+                templateExtent,
+                geometryType,
+            )
             arcpy.AddMessage("Fishnet done")
-            
+
             # intersect
             intersectOut1 = workspace + "/" + "intersectOut" + str(featID)
             itemList.append(intersectOut1)
             mergeList.append(intersectOut1)
-            inFeats = [inFeat,fishnetFeat]
+            inFeats = [inFeat, fishnetFeat]
             arcpy.Intersect_analysis(inFeats, intersectOut1)
             arcpy.AddMessage("intersect done")
             time2 = datetime.now()
             diff = time2 - time1
-            arcpy.AddMessage("took "+str(diff)+" to split this polygon.")
+            arcpy.AddMessage("took " + str(diff) + " to split this polygon.")
 
             i += 1
- 
+
         del cursor1, row1
 
-        # merge all features together   
-        
-        arcpy.Merge_management(mergeList,splitFeatClass)
+        # merge all features together
+
+        arcpy.Merge_management(mergeList, splitFeatClass)
         arcpy.AddMessage("merge done")
-        self.deleteDataItems(itemList)    
-    # This function calculates a converter value for the input area unit. The base unit is "SquareKilometers".            
-    def areaUnitConverter(self,inAreaUnit):
+        self.deleteDataItems(itemList)
+
+    # This function calculates a converter value for the input area unit. The base unit is "SquareKilometers".
+    def areaUnitConverter(self, inAreaUnit):
         # inAreaUnit: input Area Unit
-        
+
         if inAreaUnit == "Acres":
             converter = 0.00404686
         elif inAreaUnit == "Ares":
@@ -1975,43 +2296,46 @@ class helpers(object):
         elif inAreaUnit == "SquareMillimeters":
             converter = 0.000000000001
         elif inAreaUnit == "SquareYards":
-            converter = 0.00000083613       
+            converter = 0.00000083613
 
         return converter
 
     # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
+    def convert_backslach_forwardslach(self, inText):
         # inText: input path
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
 
-        inText = inText.replace('\\','/')
+        inText = inText.replace("\\", "/")
         return inText
+
     # This function adds and calculates fields with Double type
-    def addField(self,inFeat,joinFeat,fieldName,inID,joinID,expression):
+    def addField(self, inFeat, joinFeat, fieldName, inID, joinID, expression):
         # inFeat: input featureclass (or table)
         # joinFeat: feature (or table) to be joined with the inFeat
         # fieldName: the field in the inFeat to be calculated from the joinFeat
         # inID: unique id field in the inFeat
         # joinID: unique id field in the joinFeat that matches the inID
         # expression: expression text used to calculate the field
-        
+
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
-        
+
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inFeat, fieldName, fieldType, fieldPrecision, fieldScale
+            )
 
         layerName = "tempLyr"
         arcpy.MakeFeatureLayer_management(inFeat, layerName)
@@ -2024,12 +2348,13 @@ class helpers(object):
         arcpy.Delete_management(layerName)
         arcpy.AddMessage(fieldName + " added and calculated")
         return
+
     # added 2023-06-20
     # This function delete fields not to be kept
-    def deleteFields(self,inFeat,fieldsTokeep):
+    def deleteFields(self, inFeat, fieldsTokeep):
         # inFeat: input featureclass (or table)
         # fieldsToKeep: a list of field names in inFeat to be kept
-        
+
         fieldList = arcpy.ListFields(inFeat)
         fieldsToDrop = []
         for field in fieldList:
@@ -2037,29 +2362,30 @@ class helpers(object):
                 if field.name not in fieldsTokeep:
                     fieldsToDrop.append(field.name)
         if len(fieldsToDrop) > 0:
-            arcpy.DeleteField_management(inFeat,fieldsToDrop)
+            arcpy.DeleteField_management(inFeat, fieldsToDrop)
         return
-        
 
     # This function adds and calculates fields with Text type
-    def addTextField(self,inFeat,joinFeat,fieldName,inID,joinID,expression):
+    def addTextField(self, inFeat, joinFeat, fieldName, inID, joinID, expression):
         # inFeat: input featureclass (or table)
         # joinFeat: feature (or table) to be joined with the inFeat
         # fieldName: the field in the inFeat to be calculated from the joinFeat
         # inID: unique id field in the inFeat
         # joinID: unique id field in the joinFeat that matches the inID
         # expression: expression text used to calculate the field
-        
+
         fieldType = "TEXT"
         fieldLength = 200
-        
+
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
-        
+
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,field_length=fieldLength)
+            arcpy.AddField_management(
+                inFeat, fieldName, fieldType, field_length=fieldLength
+            )
 
         layerName = "tempLyr"
         arcpy.MakeFeatureLayer_management(inFeat, layerName)
@@ -2072,64 +2398,83 @@ class helpers(object):
         arcpy.Delete_management(layerName)
         arcpy.AddMessage(fieldName + " added and calculated")
         return
+
     # This function adds a featID field with unique ID values
-    def addIDField(self,inFeat,fieldName):
-        # inFeat: input featureclass (or table)       
-        # fieldName: the field in the inFeat to be calculated from the joinFeat        
-        
+    def addIDField(self, inFeat, fieldName):
+        # inFeat: input featureclass (or table)
+        # fieldName: the field in the inFeat to be calculated from the joinFeat
+
         fieldType = "LONG"
         fieldPrecision = 15
-        
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
-        
+
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(inFeat, fieldName, fieldType, fieldPrecision)
 
         expression = "!OBJECTID!"
 
         arcpy.CalculateField_management(inFeat, fieldName, expression, "PYTHON_9.3")
-        
+
         arcpy.AddMessage(fieldName + " added and calculated")
         return
+
     # This function deletes all intermediate data items
-    def deleteDataItems(self,inDataList):
+    def deleteDataItems(self, inDataList):
         # inDataList: a list of data items to be deleted
-        
+
         if len(inDataList) == 0:
-            arcpy.AddMessage("no data item in the list")            
+            arcpy.AddMessage("no data item in the list")
         else:
             for item in inDataList:
                 arcpy.AddMessage("Deleting " + item)
                 arcpy.Delete_management(item)
         return
-    # This functions calculates Compactness 
-    def calculateCompactness(self,inFeatClass):
+
+    # This functions calculates Compactness
+    def calculateCompactness(self, inFeatClass):
         # inFeatClass: input Bathymetry High (Low) features
-        
+
         fieldType = "DOUBLE"
         fieldPrecision = 15
         fieldScale = 6
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
-        fieldName = 'Compactness'
+        fieldName = "Compactness"
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeatClass,fieldName,fieldType,fieldPrecision,fieldScale)
+            arcpy.AddField_management(
+                inFeatClass, fieldName, fieldType, fieldPrecision, fieldScale
+            )
 
         # This is the compactness equation
-        expression = "4*math.pi*" + "!" + "SHAPE_AREA" + "!" + "/" + "!" + "SHAPE_LENGTH" + "!" + "/" + "!" + "SHAPE_LENGTH" + "!"       
-        arcpy.CalculateField_management(inFeatClass,fieldName,expression, "PYTHON_9.3")
+        expression = (
+            "4*math.pi*"
+            + "!"
+            + "SHAPE_AREA"
+            + "!"
+            + "/"
+            + "!"
+            + "SHAPE_LENGTH"
+            + "!"
+            + "/"
+            + "!"
+            + "SHAPE_LENGTH"
+            + "!"
+        )
+        arcpy.CalculateField_management(
+            inFeatClass, fieldName, expression, "PYTHON_9.3"
+        )
         arcpy.AddMessage(fieldName + " added and calculated")
 
     # This function calculates Circularity, Convexity and Solidity
-    def calculateCircularity_Convexity_Solidity(self,inFeatClass):
+    def calculateCircularity_Convexity_Solidity(self, inFeatClass):
         # inFeatClass: input Bathymetry High (Low) features
-        
+
         itemList = []
         fieldType = "DOUBLE"
         fieldPrecision = 15
@@ -2139,47 +2484,76 @@ class helpers(object):
         # generate bounding convex hull
         chFeat = "convex_hull"
         itemList.append(chFeat)
-        arcpy.MinimumBoundingGeometry_management(inFeatClass, chFeat, "CONVEX_HULL", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeatClass, chFeat, "CONVEX_HULL", "NONE", "", "MBG_FIELDS"
+        )
         # add area and perimeter fields of chFeat to inFeatClass
 
         field = "convexhull_Area"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + chFeat + "." + "SHAPE_AREA" + "!"        
-        self.addField(inFeatClass,chFeat,field,inID,joinID,expression)
+        expression = "!" + chFeat + "." + "SHAPE_AREA" + "!"
+        self.addField(inFeatClass, chFeat, field, inID, joinID, expression)
         field = "convexhull_Perimeter"
         expression = "!" + chFeat + "." + "SHAPE_LENGTH" + "!"
-        self.addField(inFeatClass,chFeat,field,inID,joinID,expression)
+        self.addField(inFeatClass, chFeat, field, inID, joinID, expression)
         arcpy.AddMessage("two convex hull fields added")
 
-        fieldList = ['Circularity','Convexity','Solidity']
-        for fieldName in fieldList:            
+        fieldList = ["Circularity", "Convexity", "Solidity"]
+        for fieldName in fieldList:
             if fieldName in field_names:
                 arcpy.AddMessage(fieldName + " exists and will be recalculated")
             else:
-                arcpy.AddField_management(inFeatClass,fieldName,fieldType,fieldPrecision,fieldScale)
+                arcpy.AddField_management(
+                    inFeatClass, fieldName, fieldType, fieldPrecision, fieldScale
+                )
 
             if fieldName == "Circularity":
                 # Circularity equation
-                expression = "4*math.pi*" + "!" + "SHAPE_AREA" + "!" + "/" + "!" + "convexhull_Perimeter" + "!" + "/" + "!" + "convexhull_Perimeter" + "!"
+                expression = (
+                    "4*math.pi*"
+                    + "!"
+                    + "SHAPE_AREA"
+                    + "!"
+                    + "/"
+                    + "!"
+                    + "convexhull_Perimeter"
+                    + "!"
+                    + "/"
+                    + "!"
+                    + "convexhull_Perimeter"
+                    + "!"
+                )
             elif fieldName == "Convexity":
                 # Convexity equation
-                expression = "!" + "convexhull_Perimeter" + "!" + "/" + "!" + "SHAPE_LENGTH" + "!"
+                expression = (
+                    "!"
+                    + "convexhull_Perimeter"
+                    + "!"
+                    + "/"
+                    + "!"
+                    + "SHAPE_LENGTH"
+                    + "!"
+                )
             elif fieldName == "Solidity":
                 # Solidiy equation
-                expression = "!" + "SHAPE_AREA" + "!" + "/" + "!" + "convexhull_Area" + "!"
-                
-            arcpy.CalculateField_management(inFeatClass,fieldName,expression, "PYTHON_9.3")
+                expression = (
+                    "!" + "SHAPE_AREA" + "!" + "/" + "!" + "convexhull_Area" + "!"
+                )
+
+            arcpy.CalculateField_management(
+                inFeatClass, fieldName, expression, "PYTHON_9.3"
+            )
         arcpy.AddMessage(" Circularity, Convexity and Solidity added and calculated")
         self.deleteDataItems(itemList)
 
     # This functions calculates sinuosity, length to width ratio, and other shape attributes for the Bathymetric High features
-    def calculateSinuosity_LwR(self,workspace,tempFolder,inFeatClass,inBathy):
+    def calculateSinuosity_LwR(self, workspace, tempFolder, inFeatClass, inBathy):
         # workspace: the location of the workspace
         # tempFolder: the location of the temporary folder
         # inFeatClass: input Bathymetry High (Low) features
         # inBathy: input bathymetry grid
-        
+
         env.workspace = workspace
         time1 = datetime.now()
         itemList = []
@@ -2191,108 +2565,132 @@ class helpers(object):
         # generate bounding rectangle
         MbrFeatClass = "bounding_rectangle"
         itemList.append(MbrFeatClass)
-        arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         # add MBG_LENGTH, MBG_WIDTH AND MBG_ORIENTATION to inFeatClass
         field = "rectangle_Length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + MbrFeatClass + "." + "MBG_Length" + "!"        
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        expression = "!" + MbrFeatClass + "." + "MBG_Length" + "!"
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         field = "rectangle_Width"
         expression = "!" + MbrFeatClass + "." + "MBG_Width" + "!"
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         field = "rectangle_Orientation"
         expression = "!" + MbrFeatClass + "." + "MBG_Orientation" + "!"
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         arcpy.AddMessage("three bounding rectangle fields added")
 
-        fieldList = ['head_foot_length','sinuous_length','Sinuosity','mean_width','LengthWidthRatio']
-        
-        for fieldName in fieldList:            
+        fieldList = [
+            "head_foot_length",
+            "sinuous_length",
+            "Sinuosity",
+            "mean_width",
+            "LengthWidthRatio",
+        ]
+
+        for fieldName in fieldList:
             if fieldName in field_names:
                 arcpy.AddMessage(fieldName + " exists and will be recalculated")
             else:
-                arcpy.AddField_management(inFeatClass,fieldName,fieldType,fieldPrecision,fieldScale)
-        # call the helper function to split each polygon in the inFeatClass into multiple polygons 
+                arcpy.AddField_management(
+                    inFeatClass, fieldName, fieldType, fieldPrecision, fieldScale
+                )
+        # call the helper function to split each polygon in the inFeatClass into multiple polygons
         splitFeatClass = workspace + "/" + "inFeatClass_splitted"
         itemList.append(splitFeatClass)
-        self.splitPolygon(workspace,inFeatClass,MbrFeatClass,splitFeatClass)
+        self.splitPolygon(workspace, inFeatClass, MbrFeatClass, splitFeatClass)
         arcpy.AddMessage("inFeatClass splitted")
         # convert polygon to line
         lineFeatClass1 = workspace + "/" + "lineFeatClass1"
         itemList.append(lineFeatClass1)
-        arcpy.PolygonToLine_management(splitFeatClass,lineFeatClass1)
+        arcpy.PolygonToLine_management(splitFeatClass, lineFeatClass1)
         arcpy.AddMessage("ploygon to line done")
         # selection
         lineFeatClass2 = workspace + "/" + "lineFeatClass2"
         itemList.append(lineFeatClass2)
         whereClause = "LEFT_FID <> -1"
-        arcpy.Select_analysis(lineFeatClass1,lineFeatClass2,whereClause)
+        arcpy.Select_analysis(lineFeatClass1, lineFeatClass2, whereClause)
         arcpy.AddMessage("selection done")
         # spatial join
         lineFeatClass3 = workspace + "/" + "lineFeatClass3"
         itemList.append(lineFeatClass3)
-        arcpy.SpatialJoin_analysis(lineFeatClass2,inFeatClass,lineFeatClass3,"JOIN_ONE_TO_ONE","KEEP_ALL","#","WITHIN")
+        arcpy.SpatialJoin_analysis(
+            lineFeatClass2,
+            inFeatClass,
+            lineFeatClass3,
+            "JOIN_ONE_TO_ONE",
+            "KEEP_ALL",
+            "#",
+            "WITHIN",
+        )
         arcpy.AddMessage("spatial join done")
         # summary statistics
         outTab1 = "outTab1"
         itemList.append(outTab1)
-        statsField = [["Shape_Length","SUM"]]
-        caseField = ["RIGHT_FID","featID"]
-        arcpy.Statistics_analysis(lineFeatClass3,outTab1,statsField,caseField)
+        statsField = [["Shape_Length", "SUM"]]
+        caseField = ["RIGHT_FID", "featID"]
+        arcpy.Statistics_analysis(lineFeatClass3, outTab1, statsField, caseField)
 
         outTab2 = "outTab2"
         itemList.append(outTab2)
-        statsField = [["SUM_Shape_Length","MEAN"]]
+        statsField = [["SUM_Shape_Length", "MEAN"]]
         caseField = "featID"
-        arcpy.Statistics_analysis(outTab1,outTab2,statsField,caseField)
+        arcpy.Statistics_analysis(outTab1, outTab2, statsField, caseField)
         arcpy.AddMessage("summary statistics done")
         # add mean_width field
         field = "mean_width"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "outTab2" + "." + "MEAN_SUM_Shape_Length" + "!"        
-        self.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + "outTab2" + "." + "MEAN_SUM_Shape_Length" + "!"
+        self.addField(inFeatClass, outTab2, field, inID, joinID, expression)
         arcpy.AddMessage("add mean_width field done")
         # convert feature vertices to points
         inFeatVertices = workspace + "/" + "inFeatVertices"
         itemList.append(inFeatVertices)
-        arcpy.FeatureVerticesToPoints_management(inFeatClass,inFeatVertices,"ALL")
-        arcpy.AddMessage("feature vertices to points done")       
-        
+        arcpy.FeatureVerticesToPoints_management(inFeatClass, inFeatVertices, "ALL")
+        arcpy.AddMessage("feature vertices to points done")
+
         # add x and y
         arcpy.AddXY_management(inFeatVertices)
         arcpy.AddMessage("Add x and y done")
 
         # export table as csv file
-        csvFile1 = tempFolder + '/inFile1.csv'
+        csvFile1 = tempFolder + "/inFile1.csv"
         itemList.append(csvFile1)
         # delete schema.ini which may contains incorrect data types (2023-04-20)
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
-            os.remove(schemaFile)                   
+            os.remove(schemaFile)
         # delete not required fields (2023-06-20)
-        fieldsToKeep = ['featID','rectangle_Orientation','POINT_X','POINT_Y']
-        self.deleteFields(inFeatVertices,fieldsToKeep)
+        fieldsToKeep = ["featID", "rectangle_Orientation", "POINT_X", "POINT_Y"]
+        self.deleteFields(inFeatVertices, fieldsToKeep)
         arcpy.AddMessage("delete fields done")
-        
-        arcpy.CopyRows_management(inFeatVertices,csvFile1)
+
+        arcpy.CopyRows_management(inFeatVertices, csvFile1)
         arcpy.AddMessage("export to first csv done")
         # read the csv file as a pandas data frame, add dtype parameter (2023-06-20)
         # this is to prevent mix type warning and potentially improve efficency in reading a large csv file
-        dtypeD = {'OBJECTID': np.int64, 'featID': np.int64, 'rectangle_Orientation': np.float64, 'POINT_X': np.float64, 'POINT_Y': np.float64}
-        testDF1 = pd.read_csv(csvFile1,sep=',',header=0,dtype=dtypeD)
-        testDF1.set_index('OBJECTID',inplace=True)
+        dtypeD = {
+            "OBJECTID": np.int64,
+            "featID": np.int64,
+            "rectangle_Orientation": np.float64,
+            "POINT_X": np.float64,
+            "POINT_Y": np.float64,
+        }
+        testDF1 = pd.read_csv(csvFile1, sep=",", header=0, dtype=dtypeD)
+        testDF1.set_index("OBJECTID", inplace=True)
         headfootList = []
         ids = np.unique(testDF1.featID)
         # loop through each feature which contains a number of points
         # The idea is to find a point representing 'head' (or first) and a point representing 'foot' (or last) of the feature
         for id in ids:
-            x =testDF1.loc[testDF1.featID == id]
-            angle = round(x.rectangle_Orientation.values[0],2)
+            x = testDF1.loc[testDF1.featID == id]
+            angle = round(x.rectangle_Orientation.values[0], 2)
             arcpy.AddMessage(angle)
             if (angle >= 45) & (angle <= 135):
-                y1 = x.loc[x.POINT_X == x.POINT_X.min()]        
+                y1 = x.loc[x.POINT_X == x.POINT_X.min()]
                 y2 = x.loc[x.POINT_X == x.POINT_X.max()]
                 for i in y1.index:
                     headfootList.append(i)
@@ -2306,51 +2704,57 @@ class helpers(object):
                 for i in y2.index:
                     headfootList.append(i)
 
- 
         # generate 'head' and 'foot' featureclass
-        text = '('
+        text = "("
         for i in headfootList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         pointFeat1 = workspace + "/" + "pointFeat1"
         itemList.append(pointFeat1)
-        arcpy.Select_analysis(inFeatVertices,pointFeat1,whereClause)
+        arcpy.Select_analysis(inFeatVertices, pointFeat1, whereClause)
         arcpy.AddMessage("selection done")
- 
-        
+
         # extract bathy values to points
 
         # expand inBathy
         inFocal = inBathy + "_focal"
         itemList.append(inFocal)
-        outFocalStat = FocalStatistics(inBathy, NbrRectangle(3,3,"CELL"),"MEAN","DATA")
+        outFocalStat = FocalStatistics(
+            inBathy, NbrRectangle(3, 3, "CELL"), "MEAN", "DATA"
+        )
         outFocalStat.save(inFocal)
 
-        inRasterList = [[inBathy,"depth"],[inFocal,"depth1"]]
+        inRasterList = [[inBathy, "depth"], [inFocal, "depth1"]]
         ExtractMultiValuesToPoints(pointFeat1, inRasterList, "NONE")
         arcpy.AddMessage("extract bathy values done")
-        
+
         # export table as csv file
-        csvFile2 = tempFolder + '/inFile2.csv'
+        csvFile2 = tempFolder + "/inFile2.csv"
         itemList.append(csvFile2)
         # delete schema.ini which may contains incorrect data types (2023-04-20)
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
-            os.remove(schemaFile)                    
+            os.remove(schemaFile)
 
-        
-        arcpy.CopyRows_management(pointFeat1,csvFile2)
+        arcpy.CopyRows_management(pointFeat1, csvFile2)
         arcpy.AddMessage("export to second csv done")
         # read the csv file as a pandas data frame, add dtype parameter (2023-06-20)
-        dtypeD = {'OBJECTID': np.int64, 'featID': np.int64, 'rectangle_Orientation': np.float64, 
-          'POINT_X': np.float64, 'POINT_Y': np.float64, 'depth': np.float64, 'depth1': np.float64}
-        testDF2 = pd.read_csv(csvFile2,sep=',',header=0,dtype=dtypeD)
-        testDF2.set_index('OBJECTID',inplace=True)
+        dtypeD = {
+            "OBJECTID": np.int64,
+            "featID": np.int64,
+            "rectangle_Orientation": np.float64,
+            "POINT_X": np.float64,
+            "POINT_Y": np.float64,
+            "depth": np.float64,
+            "depth1": np.float64,
+        }
+        testDF2 = pd.read_csv(csvFile2, sep=",", header=0, dtype=dtypeD)
+        testDF2.set_index("OBJECTID", inplace=True)
         # if depth has nan, replace them with depth1
-        depthList = testDF2.loc[testDF2.depth.isnull(),'depth1']
+        depthList = testDF2.loc[testDF2.depth.isnull(), "depth1"]
         if depthList.size > 0:
-            testDF2.loc[testDF2.depth.isnull(),'depth'] = depthList
+            testDF2.loc[testDF2.depth.isnull(), "depth"] = depthList
 
         # get 'head' (first) and 'foot' (last) of each feature
         ids = np.unique(testDF2.featID)
@@ -2358,7 +2762,7 @@ class helpers(object):
         lastList = []
         for id in ids:
             x = testDF2.loc[testDF2.featID == id]
-            angle = round(x.rectangle_Orientation.values[0],2)
+            angle = round(x.rectangle_Orientation.values[0], 2)
             if (angle >= 45) & (angle <= 135):
                 y1 = x.loc[x.POINT_X == x.POINT_X.min()]
                 depth1 = y1.depth.max()
@@ -2375,7 +2779,7 @@ class helpers(object):
                     z2 = y2.loc[y2.depth == depth2]
 
                     firstList.append(z1.index.values[0])
-                    lastList.append(z2.index.values[0])     
+                    lastList.append(z2.index.values[0])
             else:
                 y1 = x.loc[x.POINT_Y == x.POINT_Y.min()]
                 depth1 = y1.depth.max()
@@ -2394,41 +2798,40 @@ class helpers(object):
                     firstList.append(z1.index.values[0])
                     lastList.append(z2.index.values[0])
 
-
         # generate first points featureclass
-        text = '('
+        text = "("
         for i in firstList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         firstFeatClass = workspace + "/" + "firstPoints"
         itemList.append(firstFeatClass)
-        arcpy.Select_analysis(pointFeat1,firstFeatClass,whereClause)
+        arcpy.Select_analysis(pointFeat1, firstFeatClass, whereClause)
         # generate last points featureclass
-        text = '('
+        text = "("
         for i in lastList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         lastFeatClass = workspace + "/" + "lastPoints"
         itemList.append(lastFeatClass)
-        arcpy.Select_analysis(pointFeat1,lastFeatClass,whereClause)
+        arcpy.Select_analysis(pointFeat1, lastFeatClass, whereClause)
         arcpy.AddMessage("generate first and last points features done")
-        
+
         # polygon to point
-        pointFeat2 = workspace + "/" + "pointFeat2" 
+        pointFeat2 = workspace + "/" + "pointFeat2"
         itemList.append(pointFeat2)
         # Use FeatureToPoint function to find a point inside each part
         arcpy.FeatureToPoint_management(splitFeatClass, pointFeat2, "CENTROID")
         arcpy.AddMessage("feature to point done")
 
         # sort the points
-        pointFeat2_1 = workspace + "/" + "pointFeat2_1" 
+        pointFeat2_1 = workspace + "/" + "pointFeat2_1"
         itemList.append(pointFeat2_1)
-        pointFeat2_2 = workspace + "/" + "pointFeat2_2" 
-        itemList.append(pointFeat2_2)       
-        arcpy.Sort_management(pointFeat2,pointFeat2_1,[["ORIG_FID","ASCENDING"]]) 
-        arcpy.Sort_management(pointFeat2,pointFeat2_2,[["ORIG_FID","DESCENDING"]])
+        pointFeat2_2 = workspace + "/" + "pointFeat2_2"
+        itemList.append(pointFeat2_2)
+        arcpy.Sort_management(pointFeat2, pointFeat2_1, [["ORIG_FID", "ASCENDING"]])
+        arcpy.Sort_management(pointFeat2, pointFeat2_2, [["ORIG_FID", "DESCENDING"]])
 
         # add x and y
         arcpy.AddXY_management(pointFeat2_1)
@@ -2436,37 +2839,37 @@ class helpers(object):
         arcpy.AddMessage("Add x and y done")
 
         # merge the first point, the centre points of each sub-polygon, then the last point
-        mergedFeats = [firstFeatClass,pointFeat2_1,lastFeatClass] 
+        mergedFeats = [firstFeatClass, pointFeat2_1, lastFeatClass]
         mergedFeat1_1 = workspace + "/" + "merged_points1_1"
         itemList.append(mergedFeat1_1)
         arcpy.Merge_management(mergedFeats, mergedFeat1_1)
 
-        mergedFeats = [firstFeatClass,pointFeat2_2,lastFeatClass] 
+        mergedFeats = [firstFeatClass, pointFeat2_2, lastFeatClass]
         mergedFeat1_2 = workspace + "/" + "merged_points1_2"
         itemList.append(mergedFeat1_2)
         arcpy.Merge_management(mergedFeats, mergedFeat1_2)
-        arcpy.AddMessage("merged done")        
-        
+        arcpy.AddMessage("merged done")
+
         # point to line
         lineFeat1_1 = "curveLine1"
         itemList.append(lineFeat1_1)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat1_1, lineFeat1_1, lineField, sortField)
 
         lineFeat1_2 = "curveLine2"
         itemList.append(lineFeat1_2)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat1_2, lineFeat1_2, lineField, sortField)
         arcpy.AddMessage("points to curve line done")
 
         # merge curvelines
         # We donot know which curveline is the true curveline connecting the points in correct order.
         # Thus we merge the two curvelines together and select the one with shorter length, which is the correct one
-        mergedFeats = [lineFeat1_1,lineFeat1_2]
+        mergedFeats = [lineFeat1_1, lineFeat1_2]
         mergedCurveFeat = workspace + "/" + "merged_curves"
         itemList.append(mergedCurveFeat)
         arcpy.Merge_management(mergedFeats, mergedCurveFeat)
@@ -2476,23 +2879,23 @@ class helpers(object):
         # in order to select the shorter curveline
         outTab3 = "outTab3"
         itemList.append(outTab3)
-        statsField = [["Shape_Length","MIN"]]
+        statsField = [["Shape_Length", "MIN"]]
         caseField = ["featID"]
-        arcpy.Statistics_analysis(mergedCurveFeat,outTab3,statsField,caseField)
+        arcpy.Statistics_analysis(mergedCurveFeat, outTab3, statsField, caseField)
 
         # merge to create a straight line connecting the first and last point in order to calculate the straight length (head to foot length)
-        mergedFeats = [firstFeatClass,lastFeatClass]
+        mergedFeats = [firstFeatClass, lastFeatClass]
         mergedFeat2 = workspace + "/" + "merged_points2"
         itemList.append(mergedFeat2)
         arcpy.Merge_management(mergedFeats, mergedFeat2)
         arcpy.AddMessage("merged done")
-        
+
         # point to line
         lineFeat2 = "straightLine"
         itemList.append(lineFeat2)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat2, lineFeat2, lineField, sortField)
         arcpy.AddMessage("points to straight line done")
 
@@ -2500,15 +2903,15 @@ class helpers(object):
         field = "sinuous_length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "outTab3" + "." + "MIN_Shape_Length" + "!"        
-        self.addField(inFeatClass,outTab3,field,inID,joinID,expression)
+        expression = "!" + "outTab3" + "." + "MIN_Shape_Length" + "!"
+        self.addField(inFeatClass, outTab3, field, inID, joinID, expression)
         arcpy.AddMessage("add sinuous_length field done")
         # add head_foot_length field
         field = "head_foot_length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "straightLine" + "." + "Shape_Length" + "!"        
-        self.addField(inFeatClass,lineFeat2,field,inID,joinID,expression)
+        expression = "!" + "straightLine" + "." + "Shape_Length" + "!"
+        self.addField(inFeatClass, lineFeat2, field, inID, joinID, expression)
         arcpy.AddMessage("add heat_foot_length field done")
         field = "Sinuosity"
         expression = "!sinuous_length! / !head_foot_length!"
@@ -2522,100 +2925,102 @@ class helpers(object):
         arcpy.AddMessage("data deletion done")
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to have all attributes generated.")
+        arcpy.AddMessage("took " + str(diff) + " to have all attributes generated.")
 
     # This function calculates mean_segment_slope attribute.
     # mean_segment_slope: A number of linear segments are created by connecting the head, each point of minimum depth on a profile, and the foot.
     # The slopes of the segments are calculated and averaged as this mean_segment_slope value.
-    def calculate_segmentSlope(self,inFeat,inTab,dissolveLineFeat,headFeat,footFeat,outFeat):
+    def calculate_segmentSlope(
+        self, inFeat, inTab, dissolveLineFeat, headFeat, footFeat, outFeat
+    ):
         # inFeat: input point featureclass represents points along the cross-feature profiles, each point must have a depth value
         # inTab: input table that has some statistical values calculated from inFeat
         # dissolveLineFeat: the name of the line featureclass resulted from dissolving the inLineFeat
         # headFeat: input head feature
         # footFeat: input foot feature
         # outFeat: output point featureclass represents the start and end points of line segements
-        
-        itemList = [] 
+
+        itemList = []
         # for each profile, select a point with the minimum depth
         # the outFeat is the output also used in the Near_analysis function that follow this function
         field = "min_depth"
         inID = "RIGHT_FID"
         joinID = "RIGHT_FID"
-        expression = "!" + inTab + "." + "MIN_RASTERVALU" + "!"        
-        self.addField(inFeat,inTab,field,inID,joinID,expression)
-        outFeat2 = 'inFeat_selected'
+        expression = "!" + inTab + "." + "MIN_RASTERVALU" + "!"
+        self.addField(inFeat, inTab, field, inID, joinID, expression)
+        outFeat2 = "inFeat_selected"
         itemList.append(outFeat2)
         whereClause = '"RASTERVALU" = "min_depth"'
-        arcpy.Select_analysis(inFeat,outFeat2,whereClause)
-        arcpy.Copy_management(outFeat2,outFeat)
+        arcpy.Select_analysis(inFeat, outFeat2, whereClause)
+        arcpy.Copy_management(outFeat2, outFeat)
         # count the number of profiles
         noLines = int(arcpy.GetCount_management(dissolveLineFeat).getOutput(0))
 
-        if noLines < 2: # only one profile
+        if noLines < 2:  # only one profile
             # get head depth
             cursor = arcpy.SearchCursor(headFeat)
             row = cursor.next()
             headX = row.getValue("POINT_X")
             headY = row.getValue("POINT_Y")
-            headDepth = row.getValue('depth1')
+            headDepth = row.getValue("depth1")
             del row, cursor
             # get foot depth
             cursor = arcpy.SearchCursor(footFeat)
             row = cursor.next()
             footX = row.getValue("POINT_X")
             footY = row.getValue("POINT_Y")
-            footDepth = row.getValue('depth1')
+            footDepth = row.getValue("depth1")
             del row, cursor
             # calculate distance between head and foot
-            distance = self.calculateDistance(headX,headY,footX,footY)
+            distance = self.calculateDistance(headX, headY, footX, footY)
             # calculate slope between head and foot as the mean_segment_slope
-            meanSlope = abs(self.calculateSlope(footDepth,headDepth,distance)) 
+            meanSlope = abs(self.calculateSlope(footDepth, headDepth, distance))
         else:
             # each feature in outFeat2 represents one or multiple points that have the minimum depth along a profile
             # multiple points along a profile may have the same depth value as the minimum depth
             # in this case, only one point is selected by compiling a ids_tobeDeleted list
-            # add and calculate field 
+            # add and calculate field
             # sort
-            outFeat3 = 'outFeat2_sorted'
+            outFeat3 = "outFeat2_sorted"
             itemList.append(outFeat3)
-            sortField = [['RIGHT_FID','Descending']]
-            arcpy.Sort_management(outFeat2,outFeat3,sortField)
+            sortField = [["RIGHT_FID", "Descending"]]
+            arcpy.Sort_management(outFeat2, outFeat3, sortField)
             ## get a list of ids and fids
             cursor = arcpy.SearchCursor(outFeat3)
             idList = []
             fidList = []
             for row in cursor:
-                idV = row.getValue('OBJECTID')
-                fidV = row.getValue('RIGHT_FID')
+                idV = row.getValue("OBJECTID")
+                fidV = row.getValue("RIGHT_FID")
                 idList.append(idV)
                 fidList.append(fidV)
-            del cursor,row
+            del cursor, row
             ids_tobeDeleted = []
             i = 0
             while i < len(idList):
-                idV = idList[i]    
+                idV = idList[i]
                 fidV = fidList[i]
                 if i == len(idList) - 1:
                     break
                 else:
-                    idV1 = idList[i+1]
-                    fidV1 = fidList[i+1]
+                    idV1 = idList[i + 1]
+                    fidV1 = fidList[i + 1]
                     if fidV == fidV1:
                         ids_tobeDeleted.append(idV1)
                 i += 1
-            
+
             if len(ids_tobeDeleted) > 0:
-                outFeat4 = 'outFeat3_selected'
+                outFeat4 = "outFeat3_selected"
                 itemList.append(outFeat4)
-                text = '('
+                text = "("
                 for i in ids_tobeDeleted:
-                    text = text + str(i) + ','
-                text = text[0:-1] + ')'        
-                whereClause = 'OBJECTID NOT IN ' + text
-                arcpy.Select_analysis(outFeat3,outFeat4,whereClause)
-                arcpy.Copy_management(outFeat4,outFeat)
+                    text = text + str(i) + ","
+                text = text[0:-1] + ")"
+                whereClause = "OBJECTID NOT IN " + text
+                arcpy.Select_analysis(outFeat3, outFeat4, whereClause)
+                arcpy.Copy_management(outFeat4, outFeat)
             else:
-                arcpy.Copy_management(outFeat3,outFeat)
+                arcpy.Copy_management(outFeat3, outFeat)
             # startX and startY represent the XY of the start point of the line segment
             # endX and endY represent the XY of the end point the line segment
             # note that the end point of the first segment is the start point of the second segment, and so on
@@ -2629,27 +3034,27 @@ class helpers(object):
             startDepthList = []
             endDepthList = []
             for row in cursor:
-                x = row.getValue('POINT_X')
-                y = row.getValue('POINT_Y')
-                depth = row.getValue('min_depth')
+                x = row.getValue("POINT_X")
+                y = row.getValue("POINT_Y")
+                depth = row.getValue("min_depth")
                 startXList.append(x)
                 startYList.append(y)
                 startDepthList.append(depth)
 
-            del cursor,row
+            del cursor, row
             cursor = arcpy.SearchCursor(outFeat)
             row = cursor.next()
             row = cursor.next()
             while row:
-                x = row.getValue('POINT_X')
-                y = row.getValue('POINT_Y')
-                depth = row.getValue('min_depth')
+                x = row.getValue("POINT_X")
+                y = row.getValue("POINT_Y")
+                depth = row.getValue("min_depth")
                 endXList.append(x)
                 endYList.append(y)
                 endDepthList.append(depth)
                 row = cursor.next()
 
-            del cursor,row
+            del cursor, row
             # calculate each segment slope using the XY coordinates of the start and end points
             slopeList = []
             i = 0
@@ -2658,15 +3063,17 @@ class helpers(object):
                 startY = startYList[i]
                 endX = endXList[i]
                 endY = endYList[i]
-                distance = self.calculateDistance(startX,startY,endX,endY)
-                slope = abs(self.calculateSlope(endDepthList[i],startDepthList[i],distance))
+                distance = self.calculateDistance(startX, startY, endX, endY)
+                slope = abs(
+                    self.calculateSlope(endDepthList[i], startDepthList[i], distance)
+                )
                 slopeList.append(slope)
                 i += 1
             # calculate mean segment slope
             meanSlope = np.nanmean(np.asarray(slopeList))
         self.deleteDataItems(itemList)
         return meanSlope
-    
+
     # This function calculats 8 additional attributes: mean_width_thickness_ratio, std_width_thickness_ratio, mean_thickness, mean_segment_slope,
     # width_distance_slope, width_distance_correlation, thick_distance_slope, and thick_distance_correlation. These attributes are used to
     # classify Gully, Valley and Channel, and Canyon features.
@@ -2678,71 +3085,79 @@ class helpers(object):
     # width_distance_correlation: The correlation coefficient between the widths of the sub-polygons and the distances of the sub-polygons to the feature head
     # thick_distance_slope: The slope of the linear fitting line between the thicknesses of the sub-polygons and the distances of the sub-polygons to the feature head
     # thick_distance_correlation: The correlation coefficient between the thicknesses of the sub-polygons and the distances of the sub-polygons to the feature head
-    def calculate_Ratio_Slopes(self,inLineFeat,inBathy,dissolveLineFeat,headFeat,footFeat):
+    def calculate_Ratio_Slopes(
+        self, inLineFeat, inBathy, dissolveLineFeat, headFeat, footFeat
+    ):
         # inLineFeat: input line featureclass represents cross-feature profiles
         # inBathy: input bathymetry grid (must be extended several cells from the original bathymetry grid)
         # dissolveLineFeat: the name of the line featureclass resulted from dissolving the inLineFeat
         # headFeat: input head feature
         # footFeat: input foot feature
-        
-        itemList = []        
+
+        itemList = []
         itemList.append(inLineFeat)
         itemList.append(dissolveLineFeat)
         itemList.append(headFeat)
         itemList.append(footFeat)
         # The input inLineFeat effectively contains cross-feature profiles
-        
+
         # dissolve line features
-        dissolvedField = 'RIGHT_FID'
-        arcpy.Dissolve_management(inLineFeat,dissolveLineFeat,dissolvedField)
+        dissolvedField = "RIGHT_FID"
+        arcpy.Dissolve_management(inLineFeat, dissolveLineFeat, dissolvedField)
 
         # convert line to vertices, effectively identify the start and end points of the profiles
-        outVerticeFeat1 = 'dissolveLineFeat_vertices1'
+        outVerticeFeat1 = "dissolveLineFeat_vertices1"
         itemList.append(outVerticeFeat1)
-        arcpy.FeatureVerticesToPoints_management(dissolveLineFeat,outVerticeFeat1,'All')
+        arcpy.FeatureVerticesToPoints_management(
+            dissolveLineFeat, outVerticeFeat1, "All"
+        )
 
-        # extract depth values 
-        depthFeat1 = 'outVerticeFeat_depths1'
+        # extract depth values
+        depthFeat1 = "outVerticeFeat_depths1"
         itemList.append(depthFeat1)
-        ExtractValuesToPoints(outVerticeFeat1,inBathy,depthFeat1)
+        ExtractValuesToPoints(outVerticeFeat1, inBathy, depthFeat1)
 
         # summary statistics
         # This calculates the minimum depth of the start and end points of the profile, which represents the surface depth of the feature
-        outTab1 = 'outFeat_min1'
+        outTab1 = "outFeat_min1"
         itemList.append(outTab1)
-        statField = [['RASTERVALU','MIN']]
-        caseField = 'RIGHT_FID'
-        arcpy.Statistics_analysis(depthFeat1,outTab1,statField,caseField)
+        statField = [["RASTERVALU", "MIN"]]
+        caseField = "RIGHT_FID"
+        arcpy.Statistics_analysis(depthFeat1, outTab1, statField, caseField)
 
         # densify line features so that we have more points along the profile
-        distance = '10 Meters'
-        arcpy.Densify_edit(dissolveLineFeat,'DISTANCE',distance)
+        distance = "10 Meters"
+        arcpy.Densify_edit(dissolveLineFeat, "DISTANCE", distance)
 
         # convert line to vertices
-        outVerticeFeat2 = 'dissolveLineFeat_vertices2'
+        outVerticeFeat2 = "dissolveLineFeat_vertices2"
         itemList.append(outVerticeFeat2)
-        arcpy.FeatureVerticesToPoints_management(dissolveLineFeat,outVerticeFeat2,'All')
+        arcpy.FeatureVerticesToPoints_management(
+            dissolveLineFeat, outVerticeFeat2, "All"
+        )
 
-        # extract depth values 
-        depthFeat2 = 'outVerticeFeat_depths2'
+        # extract depth values
+        depthFeat2 = "outVerticeFeat_depths2"
         itemList.append(depthFeat2)
-        ExtractValuesToPoints(outVerticeFeat2,inBathy,depthFeat2)
+        ExtractValuesToPoints(outVerticeFeat2, inBathy, depthFeat2)
 
         # summary statistics
         # This calculates the minimum depth of the profile which represents the bottom depth of the feature
-        outTab2 = 'outFeat_min2'
+        outTab2 = "outFeat_min2"
         itemList.append(outTab2)
-        statField = [['RASTERVALU','MIN']]
-        caseField = 'RIGHT_FID'
-        arcpy.Statistics_analysis(depthFeat2,outTab2,statField,caseField)
-        
+        statField = [["RASTERVALU", "MIN"]]
+        caseField = "RIGHT_FID"
+        arcpy.Statistics_analysis(depthFeat2, outTab2, statField, caseField)
+
         # call the helper function to calculate mean_segment_Slope
-        outFeat1 = 'outFeat_selected_final'
+        outFeat1 = "outFeat_selected_final"
         itemList.append(outFeat1)
-        meanSlope = self.calculate_segmentSlope(depthFeat2,outTab2,dissolveLineFeat,headFeat,footFeat,outFeat1)
+        meanSlope = self.calculate_segmentSlope(
+            depthFeat2, outTab2, dissolveLineFeat, headFeat, footFeat, outFeat1
+        )
 
         # calculate distance of the minimum depth point of each profile to the feature head
-        arcpy.Near_analysis(outFeat1,headFeat)
+        arcpy.Near_analysis(outFeat1, headFeat)
 
         # add and calculate fields
         fieldType = "DOUBLE"
@@ -2751,40 +3166,52 @@ class helpers(object):
         fields = arcpy.ListFields(dissolveLineFeat)
         field_names = [f.name for f in fields]
 
-        fieldList = ['surface_depth','min_depth','thickness','widthThicknessRatio','distance']
+        fieldList = [
+            "surface_depth",
+            "min_depth",
+            "thickness",
+            "widthThicknessRatio",
+            "distance",
+        ]
 
-        for fieldName in fieldList:            
+        for fieldName in fieldList:
             if fieldName in field_names:
                 arcpy.AddMessage(fieldName + " exists and will be recalculated")
             else:
-                arcpy.AddField_management(dissolveLineFeat,fieldName,fieldType,fieldPrecision,fieldScale)
+                arcpy.AddField_management(
+                    dissolveLineFeat, fieldName, fieldType, fieldPrecision, fieldScale
+                )
 
         field = "surface_depth"
         inID = "RIGHT_FID"
         joinID = "RIGHT_FID"
-        expression = "!" + outTab1 + "." + "MIN_RASTERVALU" + "!"        
-        self.addField(dissolveLineFeat,outTab1,field,inID,joinID,expression)
+        expression = "!" + outTab1 + "." + "MIN_RASTERVALU" + "!"
+        self.addField(dissolveLineFeat, outTab1, field, inID, joinID, expression)
 
         field = "min_depth"
         inID = "RIGHT_FID"
         joinID = "RIGHT_FID"
-        expression = "!" + outTab2 + "." + "MIN_RASTERVALU" + "!"        
-        self.addField(dissolveLineFeat,outTab2,field,inID,joinID,expression)        
-        
+        expression = "!" + outTab2 + "." + "MIN_RASTERVALU" + "!"
+        self.addField(dissolveLineFeat, outTab2, field, inID, joinID, expression)
+
         field = "distance"
         inID = "RIGHT_FID"
         joinID = "RIGHT_FID"
-        expression = "!" + outFeat1 + "." + "NEAR_DIST" + "!"        
-        self.addField(dissolveLineFeat,outFeat1,field,inID,joinID,expression)
-        
+        expression = "!" + outFeat1 + "." + "NEAR_DIST" + "!"
+        self.addField(dissolveLineFeat, outFeat1, field, inID, joinID, expression)
+
         # feature thickness equals surface depth minus bottom depth
         field = "thickness"
         expression = "!surface_depth! - !min_depth!"
-        arcpy.CalculateField_management(dissolveLineFeat, field, expression, "PYTHON_9.3")  
+        arcpy.CalculateField_management(
+            dissolveLineFeat, field, expression, "PYTHON_9.3"
+        )
 
         field = "widthThicknessRatio"
         expression = "abs(!Shape_Length! / !thickness!)"
-        arcpy.CalculateField_management(dissolveLineFeat, field, expression, "PYTHON_9.3")   
+        arcpy.CalculateField_management(
+            dissolveLineFeat, field, expression, "PYTHON_9.3"
+        )
 
         ratioList = []
         widthList = []
@@ -2793,52 +3220,53 @@ class helpers(object):
         cursor = arcpy.SearchCursor(dissolveLineFeat)
         # loop through each profile
         for row in cursor:
-            ratio = row.getValue('widthThicknessRatio')
-            if ratio == None: # caused by thickness = 0
+            ratio = row.getValue("widthThicknessRatio")
+            if ratio == None:  # caused by thickness = 0
                 ratioList.append(np.nan)
             else:
                 ratioList.append(ratio)
-            thickness = row.getValue('thickness')
+            thickness = row.getValue("thickness")
             thickList.append(thickness)
-            width = row.getValue('Shape_Length')
-            widthList.append(width)            
-            dist = row.getValue('distance')
+            width = row.getValue("Shape_Length")
+            widthList.append(width)
+            dist = row.getValue("distance")
             distList.append(dist)
-        del row,cursor
-        arcpy.AddMessage('ratioList:' + str(ratioList))
+        del row, cursor
+        arcpy.AddMessage("ratioList:" + str(ratioList))
         # obtain the number of profiles
         nuLines = int(arcpy.GetCount_management(dissolveLineFeat).getOutput(0))
         # obtain the number of non-nan value(s) in the ratioList. nan in ratioList is caused by thickness = 0
         nu_notNan = np.asarray(ratioList).size - np.isnan(np.asarray(ratioList)).sum()
-        
-        if nuLines < 2: # only one profile, set to default values
+
+        if nuLines < 2:  # only one profile, set to default values
             stdRatio = -999
             widthDistSlope = -999
             widthDistCor = -999
             thickDistSlope = -999
             thickDistCor = -999
-            if nu_notNan < 1: # all ratio values are nan
+            if nu_notNan < 1:  # all ratio values are nan
                 meanRatio = -999
             else:
-                meanRatio = np.nanmean(np.asarray(ratioList)) 
+                meanRatio = np.nanmean(np.asarray(ratioList))
         else:
             # calculate linear regression slopes and correlation coefficients
             widthArr = np.asarray(widthList)
             thickArr = np.asarray(thickList)
-            distArr = np.asarray(distList)           
+            distArr = np.asarray(distList)
 
-            arcpy.AddMessage('widthList:' + str(widthArr))
-            arcpy.AddMessage('thickList:' + str(thickArr))
-            arcpy.AddMessage('distList:' + str(distArr))
-            
-            if np.unique(widthArr).size == 1: # if all elements in widthList have the same value, the slope and correlation values are not meaningful
+            arcpy.AddMessage("widthList:" + str(widthArr))
+            arcpy.AddMessage("thickList:" + str(thickArr))
+            arcpy.AddMessage("distList:" + str(distArr))
+
+            if (
+                np.unique(widthArr).size == 1
+            ):  # if all elements in widthList have the same value, the slope and correlation values are not meaningful
                 widthDistSlope = -999
                 widthDistCor = -999
-            else: 
-                widthDistSlope,widthDistIntercept = np.polyfit(distArr,widthArr,1)
-                widthDistCor = np.corrcoef(distArr,widthArr)[0,1]
-                
-                
+            else:
+                widthDistSlope, widthDistIntercept = np.polyfit(distArr, widthArr, 1)
+                widthDistCor = np.corrcoef(distArr, widthArr)[0, 1]
+
             if nu_notNan < 1:
                 meanRatio = -999
                 stdRatio = -999
@@ -2852,92 +3280,120 @@ class helpers(object):
             else:
                 stdRatio = np.nanstd(np.asarray(ratioList))
                 meanRatio = np.nanmean(np.asarray(ratioList))
-                
-                if np.unique(thickArr).size == 1: # if all elements in thickList have the same value
+
+                if (
+                    np.unique(thickArr).size == 1
+                ):  # if all elements in thickList have the same value
                     thickDistSlope = -999
                     thickDistCor = -999
                 else:
-                    thickDistSlope,thickDistIntercept = np.polyfit(distArr,abs(thickArr),1)
-                    thickDistCor = np.corrcoef(distArr,abs(thickArr))[0,1]
-                    
+                    thickDistSlope, thickDistIntercept = np.polyfit(
+                        distArr, abs(thickArr), 1
+                    )
+                    thickDistCor = np.corrcoef(distArr, abs(thickArr))[0, 1]
+
         meanThick = np.nanmean(np.asarray(thickList))
-        
+
         self.deleteDataItems(itemList)
-        return meanRatio,stdRatio,meanThick,meanSlope,widthDistSlope,widthDistCor,thickDistSlope,thickDistCor
+        return (
+            meanRatio,
+            stdRatio,
+            meanThick,
+            meanSlope,
+            widthDistSlope,
+            widthDistCor,
+            thickDistSlope,
+            thickDistCor,
+        )
 
     # This function calculats the mean segment slope attribute. This attribute is used to
     # classify Gully, Valley and Channel, and Canyon features.
     # mean_segment_slope: A number of linear segments are created by connecting the head, each point of minimum depth on a profile, and the foot. The slopes of the segments are calculated and averaged as this value.
-    def calculate_meansegment_Slopes(self,inLineFeat,inBathy,dissolveLineFeat,headFeat,footFeat):
+    def calculate_meansegment_Slopes(
+        self, inLineFeat, inBathy, dissolveLineFeat, headFeat, footFeat
+    ):
         # inLineFeat: input line featureclass represents cross-feature profiles
         # inBathy: input bathymetry grid (must be extended several cells from the original bathymetry grid)
         # dissolveLineFeat: the name of the line featureclass resulted from dissolving the inLineFeat
         # headFeat: input head feature
         # footFeat: input foot feature
-        
-        itemList = []        
+
+        itemList = []
         itemList.append(inLineFeat)
         itemList.append(dissolveLineFeat)
         itemList.append(headFeat)
         itemList.append(footFeat)
         # The input inLineFeat effectively contains cross-feature profiles
-        
+
         # dissolve line features
-        dissolvedField = 'RIGHT_FID'
-        arcpy.Dissolve_management(inLineFeat,dissolveLineFeat,dissolvedField)
+        dissolvedField = "RIGHT_FID"
+        arcpy.Dissolve_management(inLineFeat, dissolveLineFeat, dissolvedField)
 
         # convert line to vertices, effectively identify the start and end points of the profiles
-        outVerticeFeat1 = 'dissolveLineFeat_vertices1'
+        outVerticeFeat1 = "dissolveLineFeat_vertices1"
         itemList.append(outVerticeFeat1)
-        arcpy.FeatureVerticesToPoints_management(dissolveLineFeat,outVerticeFeat1,'All')
+        arcpy.FeatureVerticesToPoints_management(
+            dissolveLineFeat, outVerticeFeat1, "All"
+        )
 
-        # extract depth values 
-        depthFeat1 = 'outVerticeFeat_depths1'
+        # extract depth values
+        depthFeat1 = "outVerticeFeat_depths1"
         itemList.append(depthFeat1)
-        ExtractValuesToPoints(outVerticeFeat1,inBathy,depthFeat1)
+        ExtractValuesToPoints(outVerticeFeat1, inBathy, depthFeat1)
 
         # summary statistics
         # This calculates the minimum depth of the start and end points of the profile, which represents the surface depth of the feature
-        outTab1 = 'outFeat_min1'
+        outTab1 = "outFeat_min1"
         itemList.append(outTab1)
-        statField = [['RASTERVALU','MIN']]
-        caseField = 'RIGHT_FID'
-        arcpy.Statistics_analysis(depthFeat1,outTab1,statField,caseField)
+        statField = [["RASTERVALU", "MIN"]]
+        caseField = "RIGHT_FID"
+        arcpy.Statistics_analysis(depthFeat1, outTab1, statField, caseField)
 
         # densify line features so that we have more points along the profile
-        distance = '10 Meters'
-        arcpy.Densify_edit(dissolveLineFeat,'DISTANCE',distance)
+        distance = "10 Meters"
+        arcpy.Densify_edit(dissolveLineFeat, "DISTANCE", distance)
 
         # convert line to vertices
-        outVerticeFeat2 = 'dissolveLineFeat_vertices2'
+        outVerticeFeat2 = "dissolveLineFeat_vertices2"
         itemList.append(outVerticeFeat2)
-        arcpy.FeatureVerticesToPoints_management(dissolveLineFeat,outVerticeFeat2,'All')
+        arcpy.FeatureVerticesToPoints_management(
+            dissolveLineFeat, outVerticeFeat2, "All"
+        )
 
-        # extract depth values 
-        depthFeat2 = 'outVerticeFeat_depths2'
+        # extract depth values
+        depthFeat2 = "outVerticeFeat_depths2"
         itemList.append(depthFeat2)
-        ExtractValuesToPoints(outVerticeFeat2,inBathy,depthFeat2)
+        ExtractValuesToPoints(outVerticeFeat2, inBathy, depthFeat2)
 
         # summary statistics
         # This calculates the minimum depth of the profile which represents the bottom depth of the feature
-        outTab2 = 'outFeat_min2'
+        outTab2 = "outFeat_min2"
         itemList.append(outTab2)
-        statField = [['RASTERVALU','MIN']]
-        caseField = 'RIGHT_FID'
-        arcpy.Statistics_analysis(depthFeat2,outTab2,statField,caseField)
-        
-        # call the helper function to calculate mean_segment_Slope
-        outFeat1 = 'outFeat_selected_final'
-        itemList.append(outFeat1)
-        meanSlope = self.calculate_segmentSlope(depthFeat2,outTab2,dissolveLineFeat,headFeat,footFeat,outFeat1)
+        statField = [["RASTERVALU", "MIN"]]
+        caseField = "RIGHT_FID"
+        arcpy.Statistics_analysis(depthFeat2, outTab2, statField, caseField)
 
-        
+        # call the helper function to calculate mean_segment_Slope
+        outFeat1 = "outFeat_selected_final"
+        itemList.append(outFeat1)
+        meanSlope = self.calculate_segmentSlope(
+            depthFeat2, outTab2, dissolveLineFeat, headFeat, footFeat, outFeat1
+        )
+
         self.deleteDataItems(itemList)
         return meanSlope
 
-
     # This function calculates sinuosity, length to width ratio, width to depth (thickness) ratio, and a number of other attributes for the Bathymetric Low features
-    def calculateSinuosity_LwR_WdR_Slopes(self,workspace,tempFolder,inFeatClass,inBathy,headFeatClass,footFeatClass,additionalOption):
+    def calculateSinuosity_LwR_WdR_Slopes(
+        self,
+        workspace,
+        tempFolder,
+        inFeatClass,
+        inBathy,
+        headFeatClass,
+        footFeatClass,
+        additionalOption,
+    ):
         # workspace: the location of the workspace
         # tempFolder: the location of the temporary folder
         # inFeatClass: input Bathymetry High (Low) features
@@ -2945,7 +3401,7 @@ class helpers(object):
         # headFeatClass: input head featureclass
         # footFeatClass: input foot featureclass
         # additionalOption: option of whether to calculate 7 additional attributes
-        
+
         env.workspace = workspace
         time1 = datetime.now()
         itemList = []
@@ -2957,120 +3413,153 @@ class helpers(object):
         # generate bounding rectangle
         MbrFeatClass = "bounding_rectangle"
         itemList.append(MbrFeatClass)
-        arcpy.MinimumBoundingGeometry_management(inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS")
+        arcpy.MinimumBoundingGeometry_management(
+            inFeatClass, MbrFeatClass, "RECTANGLE_BY_WIDTH", "NONE", "", "MBG_FIELDS"
+        )
         # add MBG_LENGTH, MBG_WIDTH AND MBG_ORIENTATION to inFeatClass
         field = "rectangle_Length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + MbrFeatClass + "." + "MBG_Length" + "!"        
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        expression = "!" + MbrFeatClass + "." + "MBG_Length" + "!"
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         field = "rectangle_Width"
         expression = "!" + MbrFeatClass + "." + "MBG_Width" + "!"
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         field = "rectangle_Orientation"
         expression = "!" + MbrFeatClass + "." + "MBG_Orientation" + "!"
-        self.addField(inFeatClass,MbrFeatClass,field,inID,joinID,expression)
+        self.addField(inFeatClass, MbrFeatClass, field, inID, joinID, expression)
         arcpy.AddMessage("three bounding rectangle fields added")
-        
+
         # the list of attributes to be calculated and added
         if additionalOption == "true":
             arcpy.AddMessage("Will calculate additional attributes")
-            fieldList = ['head_foot_length','sinuous_length','Sinuosity','mean_width','LengthWidthRatio',
-                         'mean_width_thickness_ratio','std_width_thickness_ratio','mean_thickness',
-                     'mean_segment_slope','width_distance_slope','width_distance_correlation',                
-                    'thick_distance_slope','thick_distance_correlation']
+            fieldList = [
+                "head_foot_length",
+                "sinuous_length",
+                "Sinuosity",
+                "mean_width",
+                "LengthWidthRatio",
+                "mean_width_thickness_ratio",
+                "std_width_thickness_ratio",
+                "mean_thickness",
+                "mean_segment_slope",
+                "width_distance_slope",
+                "width_distance_correlation",
+                "thick_distance_slope",
+                "thick_distance_correlation",
+            ]
         else:
             arcpy.AddMessage("Wonot calculate additional attributes")
-            fieldList = ['head_foot_length','sinuous_length','Sinuosity','mean_width','LengthWidthRatio',                         
-                     'mean_segment_slope']
+            fieldList = [
+                "head_foot_length",
+                "sinuous_length",
+                "Sinuosity",
+                "mean_width",
+                "LengthWidthRatio",
+                "mean_segment_slope",
+            ]
 
-            
-
-        for fieldName in fieldList:            
+        for fieldName in fieldList:
             if fieldName in field_names:
                 arcpy.AddMessage(fieldName + " exists and will be recalculated")
             else:
-                arcpy.AddField_management(inFeatClass,fieldName,fieldType,fieldPrecision,fieldScale)
-        # call the helper function to split each polygon in the inFeatClass into multiple sub-polygons 
+                arcpy.AddField_management(
+                    inFeatClass, fieldName, fieldType, fieldPrecision, fieldScale
+                )
+        # call the helper function to split each polygon in the inFeatClass into multiple sub-polygons
         splitFeatClass = workspace + "/" + "inFeatClass_splitted"
         itemList.append(splitFeatClass)
-        self.splitPolygon(workspace,inFeatClass,MbrFeatClass,splitFeatClass)
+        self.splitPolygon(workspace, inFeatClass, MbrFeatClass, splitFeatClass)
         arcpy.AddMessage("inFeatClass splitted")
         # convert polygon to line
         lineFeatClass1 = workspace + "/" + "lineFeatClass1"
         itemList.append(lineFeatClass1)
-        arcpy.PolygonToLine_management(splitFeatClass,lineFeatClass1)
+        arcpy.PolygonToLine_management(splitFeatClass, lineFeatClass1)
         arcpy.AddMessage("ploygon to line done")
         # selection
         lineFeatClass2 = workspace + "/" + "lineFeatClass2"
         itemList.append(lineFeatClass2)
         whereClause = "LEFT_FID <> -1"
-        arcpy.Select_analysis(lineFeatClass1,lineFeatClass2,whereClause)
+        arcpy.Select_analysis(lineFeatClass1, lineFeatClass2, whereClause)
         arcpy.AddMessage("selection done")
         # spatial join
         lineFeatClass3 = workspace + "/" + "lineFeatClass3"
         itemList.append(lineFeatClass3)
-        arcpy.SpatialJoin_analysis(lineFeatClass2,inFeatClass,lineFeatClass3,"JOIN_ONE_TO_ONE","KEEP_ALL","#","WITHIN")
-        arcpy.AddMessage("spatial join done")        
+        arcpy.SpatialJoin_analysis(
+            lineFeatClass2,
+            inFeatClass,
+            lineFeatClass3,
+            "JOIN_ONE_TO_ONE",
+            "KEEP_ALL",
+            "#",
+            "WITHIN",
+        )
+        arcpy.AddMessage("spatial join done")
         # summary statistics
         outTab1 = "outTab1"
         itemList.append(outTab1)
-        statsField = [["Shape_Length","SUM"]]
-        caseField = ["RIGHT_FID","featID"]
-        arcpy.Statistics_analysis(lineFeatClass3,outTab1,statsField,caseField)
+        statsField = [["Shape_Length", "SUM"]]
+        caseField = ["RIGHT_FID", "featID"]
+        arcpy.Statistics_analysis(lineFeatClass3, outTab1, statsField, caseField)
 
         outTab2 = "outTab2"
         itemList.append(outTab2)
-        statsField = [["SUM_Shape_Length","MEAN"]]
+        statsField = [["SUM_Shape_Length", "MEAN"]]
         caseField = "featID"
-        arcpy.Statistics_analysis(outTab1,outTab2,statsField,caseField)
+        arcpy.Statistics_analysis(outTab1, outTab2, statsField, caseField)
         arcpy.AddMessage("summary statistics done")
         # add mean_width field
         field = "mean_width"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "outTab2" + "." + "MEAN_SUM_Shape_Length" + "!"        
-        self.addField(inFeatClass,outTab2,field,inID,joinID,expression)
+        expression = "!" + "outTab2" + "." + "MEAN_SUM_Shape_Length" + "!"
+        self.addField(inFeatClass, outTab2, field, inID, joinID, expression)
         arcpy.AddMessage("add mean_width field done")
         # convert feature vertices to points
         inFeatVertices = workspace + "/" + "inFeatVertices"
         itemList.append(inFeatVertices)
-        arcpy.FeatureVerticesToPoints_management(inFeatClass,inFeatVertices,"ALL")
-        arcpy.AddMessage("feature vertices to points done")       
+        arcpy.FeatureVerticesToPoints_management(inFeatClass, inFeatVertices, "ALL")
+        arcpy.AddMessage("feature vertices to points done")
 
         # add x and y
         arcpy.AddXY_management(inFeatVertices)
         arcpy.AddMessage("Add x and y done")
 
         # export table as csv file
-        csvFile1 = tempFolder + '/inFile1.csv'
+        csvFile1 = tempFolder + "/inFile1.csv"
         itemList.append(csvFile1)
-                # delete schema.ini which may contains incorrect data types (2023-04-20)
+        # delete schema.ini which may contains incorrect data types (2023-04-20)
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
             os.remove(schemaFile)
 
         # delete not required fields (2023-06-20)
-        fieldsToKeep = ['featID','rectangle_Orientation','POINT_X','POINT_Y']
-        self.deleteFields(inFeatVertices,fieldsToKeep)
+        fieldsToKeep = ["featID", "rectangle_Orientation", "POINT_X", "POINT_Y"]
+        self.deleteFields(inFeatVertices, fieldsToKeep)
         arcpy.AddMessage("delete fields done")
-        
-        arcpy.CopyRows_management(inFeatVertices,csvFile1)
+
+        arcpy.CopyRows_management(inFeatVertices, csvFile1)
         arcpy.AddMessage("export to first csv done")
         # read the csv file as a pandas data frame, add dtype parameter (2023-06-20)
-        dtypeD = {'OBJECTID': np.int64, 'featID': np.int64, 'rectangle_Orientation': np.float64, 'POINT_X': np.float64, 'POINT_Y': np.float64}
-        testDF1 = pd.read_csv(csvFile1,sep=',',header=0,dtype=dtypeD)
-        testDF1.set_index('OBJECTID',inplace=True)
+        dtypeD = {
+            "OBJECTID": np.int64,
+            "featID": np.int64,
+            "rectangle_Orientation": np.float64,
+            "POINT_X": np.float64,
+            "POINT_Y": np.float64,
+        }
+        testDF1 = pd.read_csv(csvFile1, sep=",", header=0, dtype=dtypeD)
+        testDF1.set_index("OBJECTID", inplace=True)
         headfootList = []
         ids = np.unique(testDF1.featID)
         # loop through each feature which contains a number of points
         # The idea is to find a point representing 'head' (first) and a point representing 'foot' (last) of the Bathymetric Low feature
         for id in ids:
-            x =testDF1.loc[testDF1.featID == id]
-            angle = round(x.rectangle_Orientation.values[0],2)
+            x = testDF1.loc[testDF1.featID == id]
+            angle = round(x.rectangle_Orientation.values[0], 2)
             arcpy.AddMessage(angle)
             if (angle >= 45) & (angle <= 135):
-                y1 = x.loc[x.POINT_X == x.POINT_X.min()]        
+                y1 = x.loc[x.POINT_X == x.POINT_X.min()]
                 y2 = x.loc[x.POINT_X == x.POINT_X.max()]
                 for i in y1.index:
                     headfootList.append(i)
@@ -3084,64 +3573,82 @@ class helpers(object):
                 for i in y2.index:
                     headfootList.append(i)
 
-
         # generate head and foot featureclass
-        text = '('
+        text = "("
         for i in headfootList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         pointFeat1 = workspace + "/" + "pointFeat1"
         itemList.append(pointFeat1)
-        arcpy.Select_analysis(inFeatVertices,pointFeat1,whereClause)
+        arcpy.Select_analysis(inFeatVertices, pointFeat1, whereClause)
         arcpy.AddMessage("selection done")
 
         # extract bathy values to points
         # expand inBathy
         inFocal = inBathy + "_focal"
         itemList.append(inFocal)
-        outFocalStat = FocalStatistics(inBathy, NbrRectangle(3,3,"CELL"),"MEAN","DATA")
+        outFocalStat = FocalStatistics(
+            inBathy, NbrRectangle(3, 3, "CELL"), "MEAN", "DATA"
+        )
         outFocalStat.save(inFocal)
 
         # mosaic to new raster
         mosaicBathy = "mosaicBathy"
         itemList.append(mosaicBathy)
-        inputRasters = [inBathy,inFocal]  
-        arcpy.MosaicToNewRaster_management(inputRasters,workspace, mosaicBathy, inBathy, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
+        inputRasters = [inBathy, inFocal]
+        arcpy.MosaicToNewRaster_management(
+            inputRasters,
+            workspace,
+            mosaicBathy,
+            inBathy,
+            "32_BIT_FLOAT",
+            "#",
+            "1",
+            "FIRST",
+            "FIRST",
+        )
         arcpy.AddMessage("mosaic done")
         mosaicBathy = workspace + "/" + "mosaicBathy"
 
-        inRasterList = [[inBathy,"depth"],[inFocal,"depth1"]]
+        inRasterList = [[inBathy, "depth"], [inFocal, "depth1"]]
         ExtractMultiValuesToPoints(pointFeat1, inRasterList, "NONE")
         arcpy.AddMessage("extract bathy values done")
         # export table as csv file
-        csvFile2 = tempFolder + '/inFile2.csv'
+        csvFile2 = tempFolder + "/inFile2.csv"
         itemList.append(csvFile2)
-                # delete schema.ini which may contains incorrect data types (2023-04-20)
+        # delete schema.ini which may contains incorrect data types (2023-04-20)
         schemaFile = tempFolder + "/" + "schema.ini"
         if os.path.isfile(schemaFile):
-            os.remove(schemaFile)                    
+            os.remove(schemaFile)
 
-        
-        arcpy.CopyRows_management(pointFeat1,csvFile2)
+        arcpy.CopyRows_management(pointFeat1, csvFile2)
         arcpy.AddMessage("export to second csv done")
         # read the csv file as a pandas data frame, add dtype parameter (2023-06-20)
-        dtypeD = {'OBJECTID': np.int64, 'featID': np.int64, 'rectangle_Orientation': np.float64, 'POINT_X': np.float64, 'POINT_Y': np.float64, 'depth': np.float64, 'depth1': np.float64}
-        testDF2 = pd.read_csv(csvFile2,sep=',',header=0,dtype=dtypeD)
-        testDF2.set_index('OBJECTID',inplace=True)
+        dtypeD = {
+            "OBJECTID": np.int64,
+            "featID": np.int64,
+            "rectangle_Orientation": np.float64,
+            "POINT_X": np.float64,
+            "POINT_Y": np.float64,
+            "depth": np.float64,
+            "depth1": np.float64,
+        }
+        testDF2 = pd.read_csv(csvFile2, sep=",", header=0, dtype=dtypeD)
+        testDF2.set_index("OBJECTID", inplace=True)
         # if depth has nan, replace them with depth1
-        depthList = testDF2.loc[testDF2.depth.isnull(),'depth1']
+        depthList = testDF2.loc[testDF2.depth.isnull(), "depth1"]
         if depthList.size > 0:
-            testDF2.loc[testDF2.depth.isnull(),'depth'] = depthList
+            testDF2.loc[testDF2.depth.isnull(), "depth"] = depthList
         # get head and foot of each feature
-        ids = np.unique(testDF2.featID)        
+        ids = np.unique(testDF2.featID)
         headList = []
         footList = []
         firstList = []
         lastList = []
         for id in ids:
             x = testDF2.loc[testDF2.featID == id]
-            angle = round(x.rectangle_Orientation.values[0],2)
+            angle = round(x.rectangle_Orientation.values[0], 2)
             if (angle >= 45) & (angle <= 135):
                 y1 = x.loc[x.POINT_X == x.POINT_X.min()]
                 depth1 = y1.depth.max()
@@ -3160,7 +3667,7 @@ class helpers(object):
                     footList.append(z1.index.values[0])
                     headList.append(z2.index.values[0])
                     firstList.append(z1.index.values[0])
-                    lastList.append(z2.index.values[0])     
+                    lastList.append(z2.index.values[0])
             else:
                 y1 = x.loc[x.POINT_Y == x.POINT_Y.min()]
                 depth1 = y1.depth.max()
@@ -3181,56 +3688,55 @@ class helpers(object):
                     firstList.append(z1.index.values[0])
                     lastList.append(z2.index.values[0])
         # generate head featureclass
-        text = '('
+        text = "("
         for i in headList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
-        arcpy.Select_analysis(pointFeat1,headFeatClass,whereClause)
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
+        arcpy.Select_analysis(pointFeat1, headFeatClass, whereClause)
         # generate foot featureclass
-        text = '('
+        text = "("
         for i in footList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
-        arcpy.Select_analysis(pointFeat1,footFeatClass,whereClause)
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
+        arcpy.Select_analysis(pointFeat1, footFeatClass, whereClause)
         arcpy.AddMessage("generate head and foot features done")
 
-
         # generate first points featureclass
-        text = '('
+        text = "("
         for i in firstList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         firstFeatClass = workspace + "/" + "firstPoints"
         itemList.append(firstFeatClass)
-        arcpy.Select_analysis(pointFeat1,firstFeatClass,whereClause)
+        arcpy.Select_analysis(pointFeat1, firstFeatClass, whereClause)
         # generate last points featureclass
-        text = '('
+        text = "("
         for i in lastList:
-            text = text + str(i) + ','
-        text = text[0:-1] + ')'        
-        whereClause = 'OBJECTID IN ' + text
+            text = text + str(i) + ","
+        text = text[0:-1] + ")"
+        whereClause = "OBJECTID IN " + text
         lastFeatClass = workspace + "/" + "lastPoints"
         itemList.append(lastFeatClass)
-        arcpy.Select_analysis(pointFeat1,lastFeatClass,whereClause)
+        arcpy.Select_analysis(pointFeat1, lastFeatClass, whereClause)
         arcpy.AddMessage("generate first and last points features done")
 
         # polygon to point
-        pointFeat2 = workspace + "/" + "pointFeat2" 
+        pointFeat2 = workspace + "/" + "pointFeat2"
         itemList.append(pointFeat2)
         # Use FeatureToPoint function to find a point inside each part
         arcpy.FeatureToPoint_management(splitFeatClass, pointFeat2, "CENTROID")
         arcpy.AddMessage("feature to point done")
-        
+
         # sort the points
-        pointFeat2_1 = workspace + "/" + "pointFeat2_1" 
+        pointFeat2_1 = workspace + "/" + "pointFeat2_1"
         itemList.append(pointFeat2_1)
-        pointFeat2_2 = workspace + "/" + "pointFeat2_2" 
-        itemList.append(pointFeat2_2)       
-        arcpy.Sort_management(pointFeat2,pointFeat2_1,[["ORIG_FID","ASCENDING"]]) 
-        arcpy.Sort_management(pointFeat2,pointFeat2_2,[["ORIG_FID","DESCENDING"]])
+        pointFeat2_2 = workspace + "/" + "pointFeat2_2"
+        itemList.append(pointFeat2_2)
+        arcpy.Sort_management(pointFeat2, pointFeat2_1, [["ORIG_FID", "ASCENDING"]])
+        arcpy.Sort_management(pointFeat2, pointFeat2_2, [["ORIG_FID", "DESCENDING"]])
 
         # add x and y
         arcpy.AddXY_management(pointFeat2_1)
@@ -3238,37 +3744,37 @@ class helpers(object):
         print("Add x and y done")
 
         # merge the first point, the centre points of each sub-polygon, then the last point
-        mergedFeats = [firstFeatClass,pointFeat2_1,lastFeatClass] 
+        mergedFeats = [firstFeatClass, pointFeat2_1, lastFeatClass]
         mergedFeat1_1 = workspace + "/" + "merged_points1_1"
         itemList.append(mergedFeat1_1)
         arcpy.Merge_management(mergedFeats, mergedFeat1_1)
 
-        mergedFeats = [firstFeatClass,pointFeat2_2,lastFeatClass] 
+        mergedFeats = [firstFeatClass, pointFeat2_2, lastFeatClass]
         mergedFeat1_2 = workspace + "/" + "merged_points1_2"
         itemList.append(mergedFeat1_2)
         arcpy.Merge_management(mergedFeats, mergedFeat1_2)
-        arcpy.AddMessage("merged done")        
-        
+        arcpy.AddMessage("merged done")
+
         # point to line
         lineFeat1_1 = "curveLine1"
         itemList.append(lineFeat1_1)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat1_1, lineFeat1_1, lineField, sortField)
 
         lineFeat1_2 = "curveLine2"
         itemList.append(lineFeat1_2)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat1_2, lineFeat1_2, lineField, sortField)
         arcpy.AddMessage("points to curve line done")
 
-        #merge curvelines
+        # merge curvelines
         # We donot know which curveline is the true curveline connecting the points in correct order.
         # Thus we merge the two curvelines together and select the one with shorter length, which is the correct one
-        mergedFeats = [lineFeat1_1,lineFeat1_2]
+        mergedFeats = [lineFeat1_1, lineFeat1_2]
         mergedCurveFeat = workspace + "/" + "merged_curves"
         itemList.append(mergedCurveFeat)
         arcpy.Merge_management(mergedFeats, mergedCurveFeat)
@@ -3278,12 +3784,12 @@ class helpers(object):
         # in order to select the shorter curveline
         outTab3 = "outTab3"
         itemList.append(outTab3)
-        statsField = [["Shape_Length","MIN"]]
+        statsField = [["Shape_Length", "MIN"]]
         caseField = ["featID"]
-        arcpy.Statistics_analysis(mergedCurveFeat,outTab3,statsField,caseField)
+        arcpy.Statistics_analysis(mergedCurveFeat, outTab3, statsField, caseField)
 
         # merge to create a straight line connecting the first and last point in order to calculate the straight length (head to foot length)
-        mergedFeats = [firstFeatClass,lastFeatClass]
+        mergedFeats = [firstFeatClass, lastFeatClass]
         mergedFeat2 = workspace + "/" + "merged_points2"
         itemList.append(mergedFeat2)
         arcpy.Merge_management(mergedFeats, mergedFeat2)
@@ -3294,7 +3800,7 @@ class helpers(object):
         itemList.append(lineFeat2)
         lineField = "featID"
         sortField = "OBJECTID"
-        # Execute PointsToLine 
+        # Execute PointsToLine
         arcpy.PointsToLine_management(mergedFeat2, lineFeat2, lineField, sortField)
         arcpy.AddMessage("points to straight line done")
 
@@ -3302,15 +3808,15 @@ class helpers(object):
         field = "sinuous_length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "outTab3" + "." + "MIN_Shape_Length" + "!"        
-        self.addField(inFeatClass,outTab3,field,inID,joinID,expression)
+        expression = "!" + "outTab3" + "." + "MIN_Shape_Length" + "!"
+        self.addField(inFeatClass, outTab3, field, inID, joinID, expression)
         arcpy.AddMessage("add sinuous_length field done")
         # calculate and add head_foot_length, sinuosity and LengthWidthRatio fields
         field = "head_foot_length"
         inID = "featID"
         joinID = "featID"
-        expression = "!" + "straightLine" + "." + "Shape_Length" + "!"        
-        self.addField(inFeatClass,lineFeat2,field,inID,joinID,expression)
+        expression = "!" + "straightLine" + "." + "Shape_Length" + "!"
+        self.addField(inFeatClass, lineFeat2, field, inID, joinID, expression)
         arcpy.AddMessage("add heat_foot_length field done")
         field = "Sinuosity"
         expression = "!sinuous_length! / !head_foot_length!"
@@ -3322,25 +3828,31 @@ class helpers(object):
         arcpy.AddMessage("calculate LengthWidthRatio field done")
 
         # calculate mean widthThicknessRatio,mean segment slope and other slope parameters
-        arcpy.AddMessage("calculating mean widthThicknessRatio, mean segment slope and other slope parameters")
+        arcpy.AddMessage(
+            "calculating mean widthThicknessRatio, mean segment slope and other slope parameters"
+        )
         # using update cursor because we are going to assign new values to these attributes for each feature
         cursor = arcpy.UpdateCursor(inFeatClass)
         # loop through each feature
         i = 1
         for row in cursor:
             # only do this every 100 iterations
-            if i%100 == 1:
-                arcpy.Compact_management(workspace) # compact the geodatabase to reduce its size and potentially improve the performance
+            if i % 100 == 1:
+                arcpy.Compact_management(
+                    workspace
+                )  # compact the geodatabase to reduce its size and potentially improve the performance
                 arcpy.AddMessage("Compacted the geodatabase")
             featID = row.getValue("featID")
             lwRatio = float(row.getValue("LengthWidthRatio"))
-            arcpy.AddMessage('lwRatio: ' + str(lwRatio))
+            arcpy.AddMessage("lwRatio: " + str(lwRatio))
 
-            if additionalOption == "true": # calculate all 8 attributes
+            if additionalOption == "true":  # calculate all 8 attributes
                 # These 8 attributes: mean_width_thickness_ratio, std_width_thickness_ratio, mean_thickness, mean_segment_slope,
                 # width_distance_slope, width_distance_correlation, thick_distance_slope, and thick_distance_correlation are used to
                 # classify Gully, Valley and Channel features. These three types of features are elongated features with large LengthWidthRatio.
-                if lwRatio < 5: # skipping the non-elongated features and assigning them default values. This saves a lot time calulating these attributes.
+                if (
+                    lwRatio < 5
+                ):  # skipping the non-elongated features and assigning them default values. This saves a lot time calulating these attributes.
                     arcpy.AddMessage("skipping " + str(featID))
                     meanRatio = -999
                     stdRatio = -999
@@ -3350,89 +3862,116 @@ class helpers(object):
                     widthDistCor = -999
                     thickDistSlope = -999
                     thickDistCor = -999
-                else: # only calculate these 8 attributes for elongated features
-                    arcpy.AddMessage("working on " + str(featID))                
+                else:  # only calculate these 8 attributes for elongated features
+                    arcpy.AddMessage("working on " + str(featID))
                     time1 = datetime.now()
                     lineFeatClass4 = workspace + "/" + "lineFeatClass4"
-                    whereClause = 'featID = ' + str(featID)
-                    arcpy.Select_analysis(lineFeatClass3,lineFeatClass4,whereClause)
+                    whereClause = "featID = " + str(featID)
+                    arcpy.Select_analysis(lineFeatClass3, lineFeatClass4, whereClause)
                     dissolveLineFeat = workspace + "/" + "lineFeatClass4_dissolved"
 
                     headFeat1 = workspace + "/" + "headFeat1"
                     footFeat1 = workspace + "/" + "footFeat1"
-                    arcpy.Select_analysis(headFeatClass,headFeat1,whereClause)
-                    arcpy.Select_analysis(footFeatClass,footFeat1,whereClause)
+                    arcpy.Select_analysis(headFeatClass, headFeat1, whereClause)
+                    arcpy.Select_analysis(footFeatClass, footFeat1, whereClause)
                     # call the helper function to calculate the 8 attributes
                     # the input lineFeatClass4 effectively contains cross-feature profiles
-                    meanRatio,stdRatio,meanThick,meanSlope,widthDistSlope,widthDistCor,thickDistSlope,thickDistCor = self.calculate_Ratio_Slopes(lineFeatClass4,mosaicBathy,dissolveLineFeat,headFeat1,footFeat1)
-                    time2 = datetime.now()            
+                    (
+                        meanRatio,
+                        stdRatio,
+                        meanThick,
+                        meanSlope,
+                        widthDistSlope,
+                        widthDistCor,
+                        thickDistSlope,
+                        thickDistCor,
+                    ) = self.calculate_Ratio_Slopes(
+                        lineFeatClass4,
+                        mosaicBathy,
+                        dissolveLineFeat,
+                        headFeat1,
+                        footFeat1,
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to calculate these parameters.")
+                    arcpy.AddMessage(
+                        "took " + str(diff) + " to calculate these parameters."
+                    )
                 # assign the new values
-                row.setValue("mean_width_thickness_ratio",meanRatio)
-                row.setValue("std_width_thickness_ratio",stdRatio)
-                row.setValue("mean_thickness",meanThick)
-                row.setValue("mean_segment_slope",meanSlope)
-                row.setValue("width_distance_slope",widthDistSlope)
-                row.setValue("width_distance_correlation",widthDistCor)
-                row.setValue("thick_distance_slope",thickDistSlope)
-                row.setValue("thick_distance_correlation",thickDistCor)      
-            else: # calculate only the mean_segment slope attribute
-                if lwRatio < 5: # skipping the non-elongated features and assigning them default values. This saves a lot time calulating these attributes.
+                row.setValue("mean_width_thickness_ratio", meanRatio)
+                row.setValue("std_width_thickness_ratio", stdRatio)
+                row.setValue("mean_thickness", meanThick)
+                row.setValue("mean_segment_slope", meanSlope)
+                row.setValue("width_distance_slope", widthDistSlope)
+                row.setValue("width_distance_correlation", widthDistCor)
+                row.setValue("thick_distance_slope", thickDistSlope)
+                row.setValue("thick_distance_correlation", thickDistCor)
+            else:  # calculate only the mean_segment slope attribute
+                if (
+                    lwRatio < 5
+                ):  # skipping the non-elongated features and assigning them default values. This saves a lot time calulating these attributes.
                     arcpy.AddMessage("skipping " + str(featID))
                     meanSlope = -999
-                else: # only calculate this attribute for elongated features
-                    arcpy.AddMessage("working on " + str(featID))                
+                else:  # only calculate this attribute for elongated features
+                    arcpy.AddMessage("working on " + str(featID))
                     time1 = datetime.now()
                     lineFeatClass4 = workspace + "/" + "lineFeatClass4"
-                    whereClause = 'featID = ' + str(featID)
-                    arcpy.Select_analysis(lineFeatClass3,lineFeatClass4,whereClause)
+                    whereClause = "featID = " + str(featID)
+                    arcpy.Select_analysis(lineFeatClass3, lineFeatClass4, whereClause)
                     dissolveLineFeat = workspace + "/" + "lineFeatClass4_dissolved"
 
                     headFeat1 = workspace + "/" + "headFeat1"
                     footFeat1 = workspace + "/" + "footFeat1"
-                    arcpy.Select_analysis(headFeatClass,headFeat1,whereClause)
-                    arcpy.Select_analysis(footFeatClass,footFeat1,whereClause)
+                    arcpy.Select_analysis(headFeatClass, headFeat1, whereClause)
+                    arcpy.Select_analysis(footFeatClass, footFeat1, whereClause)
                     # call the helper function to calculate the attribute
                     # the input lineFeatClass4 effectively contains cross-feature profiles
-                    meanSlope = self.calculate_meansegment_Slopes(lineFeatClass4,mosaicBathy,dissolveLineFeat,headFeat1,footFeat1)
-                    time2 = datetime.now()            
+                    meanSlope = self.calculate_meansegment_Slopes(
+                        lineFeatClass4,
+                        mosaicBathy,
+                        dissolveLineFeat,
+                        headFeat1,
+                        footFeat1,
+                    )
+                    time2 = datetime.now()
                     diff = time2 - time1
-                    arcpy.AddMessage("took "+str(diff)+" to calculate these parameters.")
-                    
+                    arcpy.AddMessage(
+                        "took " + str(diff) + " to calculate these parameters."
+                    )
+
                 # assign the new values
-                row.setValue("mean_segment_slope",meanSlope)          
+                row.setValue("mean_segment_slope", meanSlope)
 
             cursor.updateRow(row)
             i += 1
 
-        
         del cursor, row
-        
+
         self.deleteDataItems(itemList)
         arcpy.AddMessage("data deletion done")
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to have all attributes generated.")
-        return 
-    # This function generates five profiles passing through the centre point    
-    def create_profiles1(self,inFeat,rectangleFeat,outPointFeat,tempFolder):
-        # inFeat: input polygon feature represents a Bathymetry High (Low) feature        
+        arcpy.AddMessage("took " + str(diff) + " to have all attributes generated.")
+        return
+
+    # This function generates five profiles passing through the centre point
+    def create_profiles1(self, inFeat, rectangleFeat, outPointFeat, tempFolder):
+        # inFeat: input polygon feature represents a Bathymetry High (Low) feature
         # rectangleFeat: input polygon feature represents the bounding rectangle of the Bathymetry High (Low) feature
         # outPointFeat: output point featureclass represents all profile points
         # tempFolder: the location of temporal folder
-        
+
         itemList = []
         # generate centre point
-        centreFeat = 'centreFeat'
+        centreFeat = "centreFeat"
         itemList.append(centreFeat)
         arcpy.FeatureToPoint_management(inFeat, centreFeat, "CENTROID")
         tempLayer = "tempLayer"
         itemList.append(tempLayer)
-        arcpy.MakeFeatureLayer_management(centreFeat,tempLayer)
+        arcpy.MakeFeatureLayer_management(centreFeat, tempLayer)
         # if the centre point is not inside the polygon (e.g., in case of a multipart feature after using the connection tools)
-        # we need to force it 
-        arcpy.SelectLayerByLocation_management(tempLayer,"WITHIN",inFeat)
+        # we need to force it
+        arcpy.SelectLayerByLocation_management(tempLayer, "WITHIN", inFeat)
 
         matchcount = int(arcpy.management.GetCount(tempLayer)[0])
         if matchcount == 0:
@@ -3441,7 +3980,7 @@ class helpers(object):
         # add x and y
         arcpy.AddXY_management(centreFeat)
         arcpy.AddMessage("Add x and y to centre point")
-        
+
         cursor = arcpy.SearchCursor(rectangleFeat)
         row = cursor.next()
         angle = row.getValue("MBG_Orientation")
@@ -3452,21 +3991,21 @@ class helpers(object):
         distance = float(length) + 10
         csvFile = tempFolder + "/" + "temp_point_locations.csv"
         itemList.append(csvFile)
-        lineFC = "temp_lines"    
+        lineFC = "temp_lines"
         itemList.append(lineFC)
         angleList = []
         angleList.append(angle)
-        
-        i = 0  
-        while i < 4:        
+
+        i = 0
+        while i < 4:
             angle = angle + 36
             if angle >= 180:
                 angle = angle - 180
-            
+
             angleList.append(angle)
             i += 1
-        # get the coordinates of from and to points, in order to generate profile lines 
-        fil = open(csvFile,"w")
+        # get the coordinates of from and to points, in order to generate profile lines
+        fil = open(csvFile, "w")
         fil.write("id,from_x,from_y,to_x,to_y,angle" + "\n")
         cursor = arcpy.SearchCursor(centreFeat)
         for row in cursor:
@@ -3474,49 +4013,72 @@ class helpers(object):
             centre_x = row.getValue("POINT_X")
             centre_y = row.getValue("POINT_Y")
             for angle in angleList:
-                from_x = math.sin(math.radians(angle))*distance+centre_x
-                from_y = math.cos(math.radians(angle))*distance+centre_y
-                to_x = math.sin(math.radians(angle+180))*distance+centre_x
-                to_y = math.cos(math.radians(angle+180))*distance+centre_y
-                fil.write(str(fid) + "," + str(from_x) + "," +  str(from_y) + "," + str(to_x) + "," + str(to_y) + "," + str(round(angle,2)) + "\n")
+                from_x = math.sin(math.radians(angle)) * distance + centre_x
+                from_y = math.cos(math.radians(angle)) * distance + centre_y
+                to_x = math.sin(math.radians(angle + 180)) * distance + centre_x
+                to_y = math.cos(math.radians(angle + 180)) * distance + centre_y
+                fil.write(
+                    str(fid)
+                    + ","
+                    + str(from_x)
+                    + ","
+                    + str(from_y)
+                    + ","
+                    + str(to_x)
+                    + ","
+                    + str(to_y)
+                    + ","
+                    + str(round(angle, 2))
+                    + "\n"
+                )
 
         fil.close()
         del cursor, row
 
-        arcpy.XYToLine_management(csvFile,lineFC,"from_x","from_y","to_x","to_y","GEODESIC","angle",inFeat)
+        arcpy.XYToLine_management(
+            csvFile,
+            lineFC,
+            "from_x",
+            "from_y",
+            "to_x",
+            "to_y",
+            "GEODESIC",
+            "angle",
+            inFeat,
+        )
         arcpy.AddMessage(lineFC + " is created")
-        # loop through each profile 
+        # loop through each profile
         cursor = arcpy.SearchCursor(lineFC)
         mergeFCList = []
-       
+
         for row in cursor:
             oID = row.getValue("OID")
-            whereClause = '"OID" = ' + str(oID)        
+            whereClause = '"OID" = ' + str(oID)
             sFeat = "selection_" + str(oID)
-            arcpy.Select_analysis(lineFC,sFeat,whereClause)
+            arcpy.Select_analysis(lineFC, sFeat, whereClause)
             # intersect each profile with the feature polygon
-            fcList = [sFeat,inFeat]
-            lineFC1 = 'lineFC1'
-            arcpy.Intersect_analysis(fcList,lineFC1,"ALL","","LINE")
-            
+            fcList = [sFeat, inFeat]
+            lineFC1 = "lineFC1"
+            arcpy.Intersect_analysis(fcList, lineFC1, "ALL", "", "LINE")
+
             # convert profile line to profile points along the line
             # normally, the lineFC1 should only have one feature,
             # but occasionally it has 2 or more features due to the default cluster tolerance setting in the above intersect analysis
             # the following codes obtain the length of the main line
             nuLines = int(arcpy.GetCount_management(lineFC1).getOutput(0))
-            if nuLines < 1: # if lineFC1 has no feature, skip this profile
+            if nuLines < 1:  # if lineFC1 has no feature, skip this profile
                 arcpy.Delete_management(sFeat)
                 arcpy.Delete_management(lineFC1)
             else:
                 lineLengthList = []
                 cursor2 = arcpy.SearchCursor(lineFC1)
-                for row2 in cursor2:                
+                for row2 in cursor2:
                     lineLength = row2.getValue("Shape_Length")
                     lineLengthList.append(lineLength)
-                    
+
                 del cursor2, row2
                 lineLength = max(lineLengthList)
-                
+
                 pointFC = "pointFC_" + str(oID)
                 pointFC1 = "pointFC_sorted_" + str(oID)
                 itemList.append(pointFC1)
@@ -3533,54 +4095,55 @@ class helpers(object):
                     dist = lineLength / 2
                     if dist > 10:
                         dist = 10
-                
+
                 # densify the vertices of the profile lines, effectively adding a vertice at each dist
                 arcpy.Densify_edit(lineFC1, "DISTANCE", str(dist) + " Meters")
                 # add a ID field
                 fieldType = "LONG"
                 fieldPrecision = 10
                 fieldName = "profileID"
-                arcpy.AddField_management(lineFC1,fieldName,fieldType,fieldPrecision)
+                arcpy.AddField_management(lineFC1, fieldName, fieldType, fieldPrecision)
                 expression = oID
-                arcpy.CalculateField_management(lineFC1, fieldName, expression, "PYTHON_9.3")
-                
-                arcpy.FeatureVerticesToPoints_management(lineFC1,pointFC,"ALL")
-                # spatial sort            
+                arcpy.CalculateField_management(
+                    lineFC1, fieldName, expression, "PYTHON_9.3"
+                )
+
+                arcpy.FeatureVerticesToPoints_management(lineFC1, pointFC, "ALL")
+                # spatial sort
                 sort_fields = [["Shape", "ASCENDING"]]
                 # Use UR algorithm
                 sort_method = "UR"
-                arcpy.Sort_management(pointFC,pointFC1,sort_fields,sort_method)
-                
+                arcpy.Sort_management(pointFC, pointFC1, sort_fields, sort_method)
+
                 arcpy.Delete_management(sFeat)
                 arcpy.Delete_management(lineFC1)
                 arcpy.Delete_management(pointFC)
-            
+
         del cursor, row
-        
-        
-        arcpy.Merge_management(mergeFCList,outPointFeat)
+
+        arcpy.Merge_management(mergeFCList, outPointFeat)
         arcpy.AddMessage("merge done")
-        self.deleteDataItems(itemList)    
-                    
+        self.deleteDataItems(itemList)
+
     # This function generates five cross-feature profiles
-    def create_profiles2(self,inFeat,rectangleFeat,outPointFeat,tempFolder):
+    def create_profiles2(self, inFeat, rectangleFeat, outPointFeat, tempFolder):
         # inFeat: input polygon feature represents a Bathymetry High (Low) feature
         # rectangleFeat: input polygon feature represents the bounding rectangle of the Bathymetry High (Low) feature
         # outPointFeat: output point featureclass represents all profile points
         # tempFolder: the location of temporal folder
-        
-        itemList = [] 
+
+        itemList = []
         cursor = arcpy.SearchCursor(rectangleFeat)
         row = cursor.next()
         MbrA = row.getValue("MBG_Orientation")
         MbrL = row.getValue("MBG_Length")
         MbrW = row.getValue("MBG_Width")
         del cursor, row
-        
+
         # bounding rectangle to points
         MbrPoints = "bounding_rectangle_points"
         itemList.append(MbrPoints)
-        arcpy.FeatureVerticesToPoints_management(rectangleFeat,MbrPoints,"ALL")
+        arcpy.FeatureVerticesToPoints_management(rectangleFeat, MbrPoints, "ALL")
         arcpy.AddMessage("bounding to points done")
         # add x and y
         arcpy.AddXY_management(MbrPoints)
@@ -3592,7 +4155,7 @@ class helpers(object):
         start_y = row.getValue("POINT_Y")
         row = cursor.next()
         end_x = row.getValue("POINT_X")
-        end_y = row.getValue("POINT_Y")    
+        end_y = row.getValue("POINT_Y")
         del cursor, row
 
         # create fishnet
@@ -3604,66 +4167,75 @@ class helpers(object):
         fishnetFeat = "fishnet"
         itemList.append(fishnetFeat)
         # Set the origin of the fishnet
-        originCoordinate = str(start_x) + ' ' + str(start_y)
+        originCoordinate = str(start_x) + " " + str(start_y)
 
         # Set the orientation
-        yAxisCoordinate = str(end_x) + ' ' + str(end_y)
+        yAxisCoordinate = str(end_x) + " " + str(end_y)
 
         numRows = 6
         cellSizeWidth = MbrW
         cellSizeHeight = MbrL / numRows
         numColumns = 1
 
-        oppositeCoorner = '#'
+        oppositeCoorner = "#"
 
-        # Create a point label feature class 
-        labels = 'NO_LABELS'
+        # Create a point label feature class
+        labels = "NO_LABELS"
 
         # Extent is set by origin and opposite corner - no need to use a template fc
-        templateExtent = '#'
+        templateExtent = "#"
 
         # Each output cell will be polyline
-        geometryType = 'POLYLINE'
+        geometryType = "POLYLINE"
 
-        arcpy.CreateFishnet_management(fishnetFeat, originCoordinate, yAxisCoordinate, cellSizeWidth,
-                                       cellSizeHeight, numRows, numColumns, oppositeCoorner, labels, templateExtent, geometryType)
+        arcpy.CreateFishnet_management(
+            fishnetFeat,
+            originCoordinate,
+            yAxisCoordinate,
+            cellSizeWidth,
+            cellSizeHeight,
+            numRows,
+            numColumns,
+            oppositeCoorner,
+            labels,
+            templateExtent,
+            geometryType,
+        )
         arcpy.AddMessage("Fishnet done")
 
-        
         cursor = arcpy.SearchCursor(fishnetFeat)
         mergeFCList = []
 
-        
         noFeat1 = 0
         for row in cursor:
             oID = row.getValue("OID")
             # select the 2nd to 6th lines as profiles
             if (oID > 1) & (oID < 7):
-                whereClause = '"OID" = ' + str(oID)        
+                whereClause = '"OID" = ' + str(oID)
                 sFeat = "selection_" + str(oID)
-                arcpy.Select_analysis(fishnetFeat,sFeat,whereClause)
-                fcList = [sFeat,inFeat]
-                lineFC1 = 'lineFC1'
-                
-                arcpy.Intersect_analysis(fcList,lineFC1,"ALL","","LINE")           
-            
+                arcpy.Select_analysis(fishnetFeat, sFeat, whereClause)
+                fcList = [sFeat, inFeat]
+                lineFC1 = "lineFC1"
+
+                arcpy.Intersect_analysis(fcList, lineFC1, "ALL", "", "LINE")
+
                 # normally, the lineFC1 should only have one feature,
                 # but occasionally it has 0 feature due to intersecting with a point (or does not intersect the feature at all, e.g., in case of the feature is linearly connected multipart feature)
                 # or >=2 features due to the default cluster tolerance setting in the above intersect analysis
                 # the following codes obtain the length of the main line
                 nuLines = int(arcpy.GetCount_management(lineFC1).getOutput(0))
                 noFeat1 += nuLines
-                
-                if nuLines < 1: # if lineFC1 has no feature, skip this profile
+
+                if nuLines < 1:  # if lineFC1 has no feature, skip this profile
                     arcpy.Delete_management(sFeat)
                     arcpy.Delete_management(lineFC1)
-                else: # if lineFC1 has 1 or more features
+                else:  # if lineFC1 has 1 or more features
                     lineLengthList = []
                     cursor2 = arcpy.SearchCursor(lineFC1)
-                    for row2 in cursor2:                
+                    for row2 in cursor2:
                         lineLength = row2.getValue("Shape_Length")
                         lineLengthList.append(lineLength)
-                        
+
                     del cursor2, row2
                     lineLength = max(lineLengthList)
 
@@ -3685,59 +4257,66 @@ class helpers(object):
                             dist = 10
                     # densify the vertices of the profile lines, effectively adding a vertice at each dist
                     arcpy.Densify_edit(lineFC1, "DISTANCE", str(dist) + " Meters")
-                    
+
                     # add a ID field
                     fieldType = "LONG"
                     fieldPrecision = 10
                     fieldName = "profileID"
-                    arcpy.AddField_management(lineFC1,fieldName,fieldType,fieldPrecision)
+                    arcpy.AddField_management(
+                        lineFC1, fieldName, fieldType, fieldPrecision
+                    )
                     expression = oID
-                    arcpy.CalculateField_management(lineFC1, fieldName, expression, "PYTHON_9.3")
+                    arcpy.CalculateField_management(
+                        lineFC1, fieldName, expression, "PYTHON_9.3"
+                    )
 
-                    arcpy.FeatureVerticesToPoints_management(lineFC1,pointFC,"ALL")
-                    # spatial sort            
+                    arcpy.FeatureVerticesToPoints_management(lineFC1, pointFC, "ALL")
+                    # spatial sort
                     sort_fields = [["Shape", "ASCENDING"]]
                     # Use UR algorithm
                     sort_method = "UR"
-                    arcpy.Sort_management(pointFC,pointFC1,sort_fields,sort_method)
-                    
+                    arcpy.Sort_management(pointFC, pointFC1, sort_fields, sort_method)
+
                     arcpy.Delete_management(sFeat)
                     arcpy.Delete_management(lineFC1)
                     arcpy.Delete_management(pointFC)
-                    
+
         del cursor, row
 
-        
         if noFeat1 > 0:
-            arcpy.AddMessage(str(noFeat1) + " cross-section profiles have actually been created.")
-            arcpy.Merge_management(mergeFCList,outPointFeat)
+            arcpy.AddMessage(
+                str(noFeat1) + " cross-section profiles have actually been created."
+            )
+            arcpy.Merge_management(mergeFCList, outPointFeat)
             arcpy.AddMessage("merge done")
-        # when none of the five cross-section profiles cross the input feature, we force it to generate one profile passing through the centre point    
+        # when none of the five cross-section profiles cross the input feature, we force it to generate one profile passing through the centre point
         else:
-            arcpy.AddMessage("None of the five cross-section profiles cross the input feature. Instead, we are creating one profile passing through the centre point.")
-            self.create_profiles3(inFeat,rectangleFeat,outPointFeat,tempFolder)
-        
+            arcpy.AddMessage(
+                "None of the five cross-section profiles cross the input feature. Instead, we are creating one profile passing through the centre point."
+            )
+            self.create_profiles3(inFeat, rectangleFeat, outPointFeat, tempFolder)
+
         self.deleteDataItems(itemList)
 
-    # This function generates one profile passing through the centre point 
-    def create_profiles3(self,inFeat,rectangleFeat,outPointFeat,tempFolder):
+    # This function generates one profile passing through the centre point
+    def create_profiles3(self, inFeat, rectangleFeat, outPointFeat, tempFolder):
         # inFeat: input polygon feature represents a Bathymetry High (Low) feature
         # rectangleFeat: input polygon feature represents the bounding rectangle of the Bathymetry High (Low) feature
         # outPointFeat: output point featureclass represents all profile points
         # tempFolder: the location of temporal folder
-        
+
         itemList = []
         # generate centre point
-        centreFeat = 'centreFeat'
+        centreFeat = "centreFeat"
         itemList.append(centreFeat)
         arcpy.FeatureToPoint_management(inFeat, centreFeat, "CENTROID")
-        
+
         tempLayer = "tempLayer"
         itemList.append(tempLayer)
-        arcpy.MakeFeatureLayer_management(centreFeat,tempLayer)
+        arcpy.MakeFeatureLayer_management(centreFeat, tempLayer)
         # if the centre point is not inside the polygon (e.g., in case of a multipart feature after using the connection tools)
-        # we need to force it 
-        arcpy.SelectLayerByLocation_management(tempLayer,"WITHIN",inFeat)
+        # we need to force it
+        arcpy.SelectLayerByLocation_management(tempLayer, "WITHIN", inFeat)
 
         matchcount = int(arcpy.management.GetCount(tempLayer)[0])
         if matchcount == 0:
@@ -3757,60 +4336,83 @@ class helpers(object):
         distance = float(length) + 10
         csvFile = tempFolder + "/" + "temp_point_locations.csv"
         itemList.append(csvFile)
-        lineFC = "temp_lines"    
+        lineFC = "temp_lines"
         itemList.append(lineFC)
-        
+
         angle = angle + 36
         if angle >= 180:
-            angle = angle - 180           
+            angle = angle - 180
 
         # get the coordinates of from and to points, in order to generate profile lines
-        fil = open(csvFile,"w")
+        fil = open(csvFile, "w")
         fil.write("id,from_x,from_y,to_x,to_y,angle" + "\n")
         cursor = arcpy.SearchCursor(centreFeat)
         for row in cursor:
             fid = row.getValue("ORIG_FID")
             centre_x = row.getValue("POINT_X")
             centre_y = row.getValue("POINT_Y")
-            from_x = math.sin(math.radians(angle))*distance+centre_x
-            from_y = math.cos(math.radians(angle))*distance+centre_y
-            to_x = math.sin(math.radians(angle+180))*distance+centre_x
-            to_y = math.cos(math.radians(angle+180))*distance+centre_y
-            fil.write(str(fid) + "," + str(from_x) + "," +  str(from_y) + "," + str(to_x) + "," + str(to_y) + "," + str(round(angle,2)) + "\n")
+            from_x = math.sin(math.radians(angle)) * distance + centre_x
+            from_y = math.cos(math.radians(angle)) * distance + centre_y
+            to_x = math.sin(math.radians(angle + 180)) * distance + centre_x
+            to_y = math.cos(math.radians(angle + 180)) * distance + centre_y
+            fil.write(
+                str(fid)
+                + ","
+                + str(from_x)
+                + ","
+                + str(from_y)
+                + ","
+                + str(to_x)
+                + ","
+                + str(to_y)
+                + ","
+                + str(round(angle, 2))
+                + "\n"
+            )
 
         fil.close()
         del cursor, row
 
-        arcpy.XYToLine_management(csvFile,lineFC,"from_x","from_y","to_x","to_y","GEODESIC","angle",inFeat)
+        arcpy.XYToLine_management(
+            csvFile,
+            lineFC,
+            "from_x",
+            "from_y",
+            "to_x",
+            "to_y",
+            "GEODESIC",
+            "angle",
+            inFeat,
+        )
         arcpy.AddMessage(lineFC + " is created")
-        # loop through each profile 
+        # loop through each profile
         cursor = arcpy.SearchCursor(lineFC)
         mergeFCList = []
-       
+
         for row in cursor:
             oID = row.getValue("OID")
-            whereClause = '"OID" = ' + str(oID)        
+            whereClause = '"OID" = ' + str(oID)
             sFeat = "selection_" + str(oID)
-            arcpy.Select_analysis(lineFC,sFeat,whereClause)
+            arcpy.Select_analysis(lineFC, sFeat, whereClause)
             # intersect each profile with the feature polygon
-            fcList = [sFeat,inFeat]
-            lineFC1 = 'lineFC1'
-           
-            arcpy.Intersect_analysis(fcList,lineFC1,"ALL","","LINE")
-            
+            fcList = [sFeat, inFeat]
+            lineFC1 = "lineFC1"
+
+            arcpy.Intersect_analysis(fcList, lineFC1, "ALL", "", "LINE")
+
             # convert profile line to profile points along the line
             # normally, the lineFC1 should only have one feature,
             # but occasionally it has 2 or more features due to the default cluster tolerance setting in the above intersect analysis
             # the following codes obtain the length of the main line
             lineLengthList = []
             cursor2 = arcpy.SearchCursor(lineFC1)
-            for row2 in cursor2:                
+            for row2 in cursor2:
                 lineLength = row2.getValue("Shape_Length")
                 lineLengthList.append(lineLength)
-                
+
             del cursor2, row2
             lineLength = max(lineLengthList)
-            
+
             pointFC = "pointFC_" + str(oID)
             pointFC1 = "pointFC_sorted_" + str(oID)
             itemList.append(pointFC1)
@@ -3827,100 +4429,107 @@ class helpers(object):
                 dist = lineLength / 2
                 if dist > 10:
                     dist = 10
-            
+
             # densify the vertices of the profile lines, effectively adding a vertice at each dist
             arcpy.Densify_edit(lineFC1, "DISTANCE", str(dist) + " Meters")
             # add a ID field
             fieldType = "LONG"
             fieldPrecision = 10
             fieldName = "profileID"
-            arcpy.AddField_management(lineFC1,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(lineFC1, fieldName, fieldType, fieldPrecision)
             expression = oID
-            arcpy.CalculateField_management(lineFC1, fieldName, expression, "PYTHON_9.3")
-            
-            arcpy.FeatureVerticesToPoints_management(lineFC1,pointFC,"ALL")
-            # spatial sort            
+            arcpy.CalculateField_management(
+                lineFC1, fieldName, expression, "PYTHON_9.3"
+            )
+
+            arcpy.FeatureVerticesToPoints_management(lineFC1, pointFC, "ALL")
+            # spatial sort
             sort_fields = [["Shape", "ASCENDING"]]
             # Use UR algorithm
             sort_method = "UR"
-            arcpy.Sort_management(pointFC,pointFC1,sort_fields,sort_method)
-            
+            arcpy.Sort_management(pointFC, pointFC1, sort_fields, sort_method)
+
             arcpy.Delete_management(sFeat)
             arcpy.Delete_management(lineFC1)
             arcpy.Delete_management(pointFC)
-            
+
         del cursor, row
-        
-        
-        arcpy.Merge_management(mergeFCList,outPointFeat)
+
+        arcpy.Merge_management(mergeFCList, outPointFeat)
         arcpy.AddMessage("merge done")
-        self.deleteDataItems(itemList)    
-                    
+        self.deleteDataItems(itemList)
 
     # This function calculates eucliean distance between two points
-    def calculateDistance(self,x1,y1,x2,y2):
+    def calculateDistance(self, x1, y1, x2, y2):
         # x1,y1: coordinates of the start point
         # x2,y2: coordinates of the end point
-        distance = np.sqrt(np.power(x1-x2,2)+np.power(y1-y2,2))
+        distance = np.sqrt(np.power(x1 - x2, 2) + np.power(y1 - y2, 2))
         return distance
 
     # This function calculates slope gradient of the line segment connecting two points
-    def calculateSlope(self,e1,e2,d):
+    def calculateSlope(self, e1, e2, d):
         # e1: elevation of the end point
         # e2: elevation of the start point
         # d: eucliean distance between the two point
         if d == 0:
             slope = 90.0
         else:
-            slope = (e1-e2)/d
-            slope = np.degrees(np.arctan(slope)) # slope as degree
+            slope = (e1 - e2) / d
+            slope = np.degrees(np.arctan(slope))  # slope as degree
         return slope
 
     # This function calculates a slope threshold from a elevation (depth) profile
     # the slope threshold is the slope between the point with the maximum elevation and the point with the minimum elevation
-    def calculateSlopeThreshold(self,profileDF,depthCol,xCol,yCol):
+    def calculateSlopeThreshold(self, profileDF, depthCol, xCol, yCol):
         # profileDF: profile data as a pandas dataframe
         # depthCol: the name of the depth column in the profileDF
         # xCol: the name of the x coordinate column in the profileDF
         # yCol: the name of the y coordinate column in the profileDF
-        maxDepth = profileDF.loc[profileDF[depthCol]==profileDF[depthCol].max()]
-        minDepth = profileDF.loc[profileDF[depthCol]==profileDF[depthCol].min()]
-        dist = self.calculateDistance(maxDepth[xCol].values[0],maxDepth[yCol].values[0],minDepth[xCol].values[0],minDepth[yCol].values[0])
-        slope = self.calculateSlope(maxDepth[depthCol].values[0],minDepth[depthCol].values[0],dist)
+        maxDepth = profileDF.loc[profileDF[depthCol] == profileDF[depthCol].max()]
+        minDepth = profileDF.loc[profileDF[depthCol] == profileDF[depthCol].min()]
+        dist = self.calculateDistance(
+            maxDepth[xCol].values[0],
+            maxDepth[yCol].values[0],
+            minDepth[xCol].values[0],
+            minDepth[yCol].values[0],
+        )
+        slope = self.calculateSlope(
+            maxDepth[depthCol].values[0], minDepth[depthCol].values[0], dist
+        )
         return slope
 
     # This is the main function conducting the profile analysis
     # The function is used to find knickpoint(s) along the profile
-    def profileAnalysis(self,profileDF,depthCol,xCol,yCol,idArr,slopeThreshold):
+    def profileAnalysis(self, profileDF, depthCol, xCol, yCol, idArr, slopeThreshold):
         # profileDF: profile data as a pandas dataframe
         # depthCol: the name of the depth column in the profileDF
         # xCol: the name of the x coordinate column in the profileDF
         # yCol: the name of the y coordinate column in the profileDF
         # idArr: the id array
-        # slopeThreshold: the desinated slope threshold 
+        # slopeThreshold: the desinated slope threshold
         s1List = []
         s2List = []
         # loop through each point in the profile
-        for i in profileDF.index:    
+        for i in profileDF.index:
             # split the profile into two sections: upstream and downstream of the point
             upstream = profileDF.loc[profileDF.index < i]
             downstream = profileDF.loc[profileDF.index > i]
             # get the x, y and depth values of the point being processed
-            x = profileDF.loc[i,xCol]
-            y = profileDF.loc[i,yCol]
-            depth = profileDF.loc[i,depthCol]
+            x = profileDF.loc[i, xCol]
+            y = profileDF.loc[i, yCol]
+            depth = profileDF.loc[i, depthCol]
             # doing upstream first
             # calculating the slope of the point to each of the upstream point(s)
             upSlopeList = []
             if upstream.index.size == 0:
                 upSlope = np.nan
             else:
-                for j in upstream.index:    
-                    x1 = upstream.loc[j,xCol]
-                    y1 = upstream.loc[j,yCol]
-                    depth1 = upstream.loc[j,depthCol]
-                    dist1 = self.calculateDistance(x,y,x1,y1)
-                    slope1 = self.calculateSlope(depth,depth1,dist1)
+                for j in upstream.index:
+                    x1 = upstream.loc[j, xCol]
+                    y1 = upstream.loc[j, yCol]
+                    depth1 = upstream.loc[j, depthCol]
+                    dist1 = self.calculateDistance(x, y, x1, y1)
+                    slope1 = self.calculateSlope(depth, depth1, dist1)
                     upSlopeList.append(slope1)
                 # slope of the upstream section is the mean of the individual upstream slopes
                 upSlope = np.mean(np.asarray(upSlopeList))
@@ -3930,69 +4539,78 @@ class helpers(object):
             if downstream.index.size == 0:
                 downSlope = np.nan
             else:
-                for j in downstream.index:    
-                    x1 = downstream.loc[j,xCol]
-                    y1 = downstream.loc[j,yCol]
-                    depth1 = downstream.loc[j,depthCol]
-                    dist1 = self.calculateDistance(x,y,x1,y1)
-                    slope1 = self.calculateSlope(depth1,depth,dist1)
+                for j in downstream.index:
+                    x1 = downstream.loc[j, xCol]
+                    y1 = downstream.loc[j, yCol]
+                    depth1 = downstream.loc[j, depthCol]
+                    dist1 = self.calculateDistance(x, y, x1, y1)
+                    slope1 = self.calculateSlope(depth1, depth, dist1)
                     downSlopeList.append(slope1)
                 downSlope = np.mean(np.asarray(downSlopeList))
             s2List.append(downSlope)
-       
+
         # add three new columns to the profile data
-        profileDF.loc[:,'upSlope'] = s1List
-        profileDF.loc[:,'downSlope'] = s2List
-        profileDF.loc[:,'diffSlope'] = np.abs(profileDF.loc[:,'upSlope']-profileDF.loc[:,'downSlope'])
-        
+        profileDF.loc[:, "upSlope"] = s1List
+        profileDF.loc[:, "downSlope"] = s2List
+        profileDF.loc[:, "diffSlope"] = np.abs(
+            profileDF.loc[:, "upSlope"] - profileDF.loc[:, "downSlope"]
+        )
+
         # calculate the 95th percentile of the diffSlope, as the slope threshold for the following round(s)
         diffSlope_95 = profileDF.diffSlope.quantile(0.95)
-        
+
         # select the row(s) (knick point(s))that satisfying the following criteria from the profile data
         # 1. must be larger than the 99th percentile of the diffSlope;
         # 2. must be larger than the desinated slope threshold;
         # 3. must be at least larger than 1.0 degree (to remove very flat profile).
-        #selectedID = profileDF[profileDF.diffSlope>=max(profileDF.diffSlope.mean()+2*profileDF.diffSlope.std(),slopeThreshold,1)].index.values
-        selectedID = profileDF.loc[profileDF.diffSlope>=max(profileDF.diffSlope.quantile(0.99),slopeThreshold,1)].index.values
-        
+        # selectedID = profileDF[profileDF.diffSlope>=max(profileDF.diffSlope.mean()+2*profileDF.diffSlope.std(),slopeThreshold,1)].index.values
+        selectedID = profileDF.loc[
+            profileDF.diffSlope
+            >= max(profileDF.diffSlope.quantile(0.99), slopeThreshold, 1)
+        ].index.values
+
         # removing the above row(s) from the profile data
-        #profileDF = profileDF[profileDF.diffSlope<max(profileDF.diffSlope.mean()+2*profileDF.diffSlope.std(),slopeThreshold,1)]
-        profileDF = profileDF.loc[profileDF.diffSlope<max(profileDF.diffSlope.quantile(0.99),slopeThreshold,1)].copy()
+        # profileDF = profileDF[profileDF.diffSlope<max(profileDF.diffSlope.mean()+2*profileDF.diffSlope.std(),slopeThreshold,1)]
+        profileDF = profileDF.loc[
+            profileDF.diffSlope
+            < max(profileDF.diffSlope.quantile(0.99), slopeThreshold, 1)
+        ].copy()
         # append the selected row ids into the input array to generate an updated id array
-        idArr_new = np.append(idArr,selectedID)
+        idArr_new = np.append(idArr, selectedID)
         # return the updated profile data, the input id array, the updated id array, and the 95th percentile of
         # the original profile data as the slope threshold for the following round(s)
-        return profileDF,idArr,idArr_new,diffSlope_95
+        return profileDF, idArr, idArr_new, diffSlope_95
 
-    # This function identifies group knick points, with gap less than the designated value 
-    def findGroup(self,arr,gap):
+    # This function identifies group knick points, with gap less than the designated value
+    def findGroup(self, arr, gap):
         # arr: input id array, sorted with ascending order
         # gap: maximum gap allowed between knick points to form the group
-        
+
         # create an empty array with type=int, to hold the ids of the knick points within the group
         arr1 = np.arange(0)
         # append the first element of the input array into the newly created array
-        arr1=np.append(arr1,arr[0])
+        arr1 = np.append(arr1, arr[0])
         # update the input array after removing the first element
-        mask = np.ones(len(arr),dtype=bool)
+        mask = np.ones(len(arr), dtype=bool)
         mask[0] = False
         arr = arr[mask]
         # loop through the remaining elements in the input id array and append them into the group if the difference
         # is less than the gap
-        while arr.size > 0:        
+        while arr.size > 0:
             a = arr1[-1]
             b = arr[0]
-            if b-a < gap:
-                arr1=np.append(arr1,arr[0])
-                mask = np.ones(len(arr),dtype=bool)
+            if b - a < gap:
+                arr1 = np.append(arr1, arr[0])
+                mask = np.ones(len(arr), dtype=bool)
                 mask[0] = False
                 arr = arr[mask]
             else:
                 break
         # return the list of id groups and the updated id array
-        return arr1.tolist(),arr
+        return arr1.tolist(), arr
+
     # This function calculates the slope for each profile segment, connecting the knick points
-    def profileSlope(self,profileDF,xCol,yCol,depthCol):
+    def profileSlope(self, profileDF, xCol, yCol, depthCol):
         # profileDF: profile data as a pandas dataframe
         # depthCol: the name of the depth column in the profileDF
         # xCol: the name of the x coordinate column in the profileDF
@@ -4005,23 +4623,43 @@ class helpers(object):
         i = 0
         while i < profileDF.index.size:
             # the slope for the line segment connecting the last and first point of the profile
-            if i == profileDF.index.size-1:
-                dist = self.calculateDistance(profileDF.iloc[i,xColIndex],profileDF.iloc[i,yColIndex],profileDF.iloc[0,xColIndex],profileDF.iloc[0,yColIndex])
-                slope = abs(self.calculateSlope(profileDF.iloc[i,dColIndex],profileDF.iloc[0,dColIndex],dist))
+            if i == profileDF.index.size - 1:
+                dist = self.calculateDistance(
+                    profileDF.iloc[i, xColIndex],
+                    profileDF.iloc[i, yColIndex],
+                    profileDF.iloc[0, xColIndex],
+                    profileDF.iloc[0, yColIndex],
+                )
+                slope = abs(
+                    self.calculateSlope(
+                        profileDF.iloc[i, dColIndex], profileDF.iloc[0, dColIndex], dist
+                    )
+                )
                 slList.append(slope)
                 dList.append(dist)
             # other profile segments
             else:
-                dist = self.calculateDistance(profileDF.iloc[i,xColIndex],profileDF.iloc[i,yColIndex],profileDF.iloc[i+1,xColIndex],profileDF.iloc[i+1,yColIndex])
-                slope = abs(self.calculateSlope(profileDF.iloc[i+1,dColIndex],profileDF.iloc[i,dColIndex],dist))
+                dist = self.calculateDistance(
+                    profileDF.iloc[i, xColIndex],
+                    profileDF.iloc[i, yColIndex],
+                    profileDF.iloc[i + 1, xColIndex],
+                    profileDF.iloc[i + 1, yColIndex],
+                )
+                slope = abs(
+                    self.calculateSlope(
+                        profileDF.iloc[i + 1, dColIndex],
+                        profileDF.iloc[i, dColIndex],
+                        dist,
+                    )
+                )
                 slList.append(slope)
                 dList.append(dist)
             i += 1
-        
-        return dList,slList
+
+        return dList, slList
 
     # This function calculates the angles of the polygon formed by the profile segments, connecting the knick points
-    def profileAngle(self,profileDF,slopeCol):
+    def profileAngle(self, profileDF, slopeCol):
         # profileDF: profile data as a pandas dataframe
         # slopeCol: the name of the slope column in the profileDF
         sColIndex = np.where(profileDF.columns.values == slopeCol)[0][0]
@@ -4030,31 +4668,38 @@ class helpers(object):
         while i < profileDF.index.size:
             # the first polygon angle
             if i == 0:
-                angle = abs(profileDF.iloc[i,sColIndex] - profileDF.iloc[-1,sColIndex])
+                angle = abs(
+                    profileDF.iloc[i, sColIndex] - profileDF.iloc[-1, sColIndex]
+                )
             # the last polygon angle
-            elif i == profileDF.index.size-1:
-                angle = abs(profileDF.iloc[-1,sColIndex] - profileDF.iloc[i-1,sColIndex])
+            elif i == profileDF.index.size - 1:
+                angle = abs(
+                    profileDF.iloc[-1, sColIndex] - profileDF.iloc[i - 1, sColIndex]
+                )
             # other polygon angle
             else:
-                angle = 180 - abs(profileDF.iloc[i-1,sColIndex] - profileDF.iloc[i,sColIndex])
-                
+                angle = 180 - abs(
+                    profileDF.iloc[i - 1, sColIndex] - profileDF.iloc[i, sColIndex]
+                )
+
             angleList.append(angle)
             i += 1
         return angleList
 
     # This function classifies the slope into several categories
-    def slopeClass(self,slope):
+    def slopeClass(self, slope):
         if slope < 5:
-            sClass = 'flat'
+            sClass = "flat"
         elif slope < 10:
-            sClass = 'gentle'
+            sClass = "gentle"
         elif slope < 30:
-            sClass = 'moderate'
+            sClass = "moderate"
         else:
-            sClass = 'steep'
+            sClass = "steep"
         return sClass
+
     # This function calculates the profile attributes for the Bathymetric High features
-    def calculate_profile_attributes_high(self,profileDF,depthCol,xCol,yCol,gap):
+    def calculate_profile_attributes_high(self, profileDF, depthCol, xCol, yCol, gap):
         # profileDF: profile data as a pandas dataframe
         # depthCol: the name of the depth column in the profileDF
         # xCol: the name of the x coordinate column in the profileDF
@@ -4064,41 +4709,46 @@ class helpers(object):
         yColIndex = np.where(profileDF.columns.values == yCol)[0][0]
         dColIndex = np.where(profileDF.columns.values == depthCol)[0][0]
         distL = []
-        x = profileDF.iloc[0,xColIndex]
-        y = profileDF.iloc[0,yColIndex]
+        x = profileDF.iloc[0, xColIndex]
+        y = profileDF.iloc[0, yColIndex]
         # loop through each profile
         for i in profileDF.index:
-            x1 = profileDF.loc[i,xCol]
-            y1 = profileDF.loc[i,yCol]
-            dist = self.calculateDistance(x,y,x1,y1)
+            x1 = profileDF.loc[i, xCol]
+            y1 = profileDF.loc[i, yCol]
+            dist = self.calculateDistance(x, y, x1, y1)
             distL.append(dist)
-        profileDF.loc[:,'distance'] = distL
+        profileDF.loc[:, "distance"] = distL
 
         profileDF_copy = profileDF.copy(deep=True)
-        
+
         # initialise an id array
         idArr = np.arange(0)
         # calculate a slope threshold
-        slopeThreshold = abs(self.calculateSlopeThreshold(profileDF_copy,depthCol,xCol,yCol))
-    
+        slopeThreshold = abs(
+            self.calculateSlopeThreshold(profileDF_copy, depthCol, xCol, yCol)
+        )
+
         # conduct the first round of profile analysis using the slopeThreshold
-        profileDF_copy,idArr1,idArr2,diffSlope_95 = self.profileAnalysis(profileDF_copy,depthCol,xCol,yCol,idArr,slopeThreshold)
-        
+        profileDF_copy, idArr1, idArr2, diffSlope_95 = self.profileAnalysis(
+            profileDF_copy, depthCol, xCol, yCol, idArr, slopeThreshold
+        )
+
         # conduct the follwoing round(s) of profile analysis using the diffSlope_95 as the slopeThreshold
         # stop the loop when there is no element to be appended into the new array, thus the size of the input id array equals
-        # the size of the updated id array        
+        # the size of the updated id array
         while idArr2.size > idArr1.size:
-            profileDF_copy,idArr1,idArr2,dumy_95 = self.profileAnalysis(profileDF_copy,depthCol,xCol,yCol,idArr2,diffSlope_95)
+            profileDF_copy, idArr1, idArr2, dumy_95 = self.profileAnalysis(
+                profileDF_copy, depthCol, xCol, yCol, idArr2, diffSlope_95
+            )
 
-        
         # sort the id array
-        idArray=np.sort(idArr2)
-        idList=idArray.tolist()
-        i=0
+        idArray = np.sort(idArr2)
+        idList = idArray.tolist()
+        i = 0
         # find the ids groups
         while i < len(idList):
             if idArray.size > 0:
-                idList[i],idArray = self.findGroup(idArray,gap)
+                idList[i], idArray = self.findGroup(idArray, gap)
             i += 1
 
         i = 0
@@ -4108,9 +4758,9 @@ class helpers(object):
             if type(idList[i]) == list:
                 idGroups.append(idList[i])
             i += 1
-        
+
         # identify one single knick point from each id group (ie. knick group)
-        # the selected knick point represents the first (last) point in the knick group if the group 
+        # the selected knick point represents the first (last) point in the knick group if the group
         # is closer to the start (end) point of the profile
         # select key profileDF from the original profile data
         # the selected key profileDF include the first point, the last point, and the knick profileDF in between
@@ -4141,20 +4791,19 @@ class helpers(object):
             z2.append(z_1[indexX])
             i += 1
         # select the key profileDF from the profile data to form a simplied profile (profileDF1)
-        z2.insert(0,profileDF.index[0])
-        z2.insert(len(z2),profileDF.index[-1])
+        z2.insert(0, profileDF.index[0])
+        z2.insert(len(z2), profileDF.index[-1])
         profileDF1 = profileDF.loc[z2].copy()
         # add 'knick_point' column
-        profileDF.loc[:,'knick_point'] = profileDF.loc[:,'distance'] < 0
-        profileDF.loc[z2,'knick_point'] = True
-        
-        dList,slList = self.profileSlope(profileDF1,xCol,yCol,depthCol)
-        profileDF1.loc[:,'slope'] = slList
-        profileDF1.loc[:,'dist'] = dList
-        angleList = self.profileAngle(profileDF1,'slope')
-        profileDF1.loc[:,'polygonAngle'] = angleList
+        profileDF.loc[:, "knick_point"] = profileDF.loc[:, "distance"] < 0
+        profileDF.loc[z2, "knick_point"] = True
 
-        
+        dList, slList = self.profileSlope(profileDF1, xCol, yCol, depthCol)
+        profileDF1.loc[:, "slope"] = slList
+        profileDF1.loc[:, "dist"] = dList
+        angleList = self.profileAngle(profileDF1, "slope")
+        profileDF1.loc[:, "polygonAngle"] = angleList
+
         ## calculate profile attributes
         ## topSlopeClass: the slope class of the top of a bathymetic high; 'no top' indicates a triangle shape without top
         ## sideSlopeClass: the slope class of the sides of a bathmetric high
@@ -4165,124 +4814,149 @@ class helpers(object):
         ## height: the height of the profile
         ## length: the length of the profile
 
-        sColIndex = np.where(profileDF1.columns.values == 'slope')[0][0]
-        dColIndex = np.where(profileDF1.columns.values == 'dist')[0][0]
+        sColIndex = np.where(profileDF1.columns.values == "slope")[0][0]
+        dColIndex = np.where(profileDF1.columns.values == "dist")[0][0]
         # use profile skewness to determine shape symmetry
         # add 'numeric_only = True' option to deal with the new Pandas version (2023-04-06)
-        skewness = profileDF.skew(axis=0,numeric_only=True)[depthCol]
+        skewness = profileDF.skew(axis=0, numeric_only=True)[depthCol]
         if abs(skewness) < 0.2:
             symmetry = "Symmetric"
         else:
             symmetry = "Asymmetric"
 
-           
-        if profileDF1.index.size == 2:  # The simplified profile has only two points   
-            shape = 'Flat'
-            symmetry = 'NA'
-            topClass = 'flat'
-            concave = 'NA'
-            slClass = 'NA' 
-        elif profileDF1.index.size == 3: # The simplified profile has only three profileDF, forming a triangle
+        if profileDF1.index.size == 2:  # The simplified profile has only two points
+            shape = "Flat"
+            symmetry = "NA"
+            topClass = "flat"
+            concave = "NA"
+            slClass = "NA"
+        elif (
+            profileDF1.index.size == 3
+        ):  # The simplified profile has only three profileDF, forming a triangle
             # calculate weighted averaged side slope
-            slope1 = abs(profileDF1.iloc[0,sColIndex])
-            slope2 = abs(profileDF1.iloc[1,sColIndex])
-            dist1 = abs(profileDF1.iloc[0,dColIndex])
-            dist2 = abs(profileDF1.iloc[1,dColIndex])
+            slope1 = abs(profileDF1.iloc[0, sColIndex])
+            slope2 = abs(profileDF1.iloc[1, sColIndex])
+            dist1 = abs(profileDF1.iloc[0, dColIndex])
+            dist2 = abs(profileDF1.iloc[1, dColIndex])
             # to prevent divide by 0; changed on 20230419
             if (dist1 == 0) or (dist2 == 0):
                 sideSlope = (slope1 + slope2) / 2
-            else: 
-                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (dist1 + dist2)
+            else:
+                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (
+                    dist1 + dist2
+                )
             slClass = self.slopeClass(sideSlope)
-            topClass = 'no top'
-            concave = 'Convex'
-            shape = 'Triangle'
-        else:   # The simplified profile has more than three profileDF, forming a polygon
-            slope1 = abs(profileDF1.iloc[0,sColIndex])
-            slope2 = abs(profileDF1.iloc[-2,sColIndex])
-            dist1 = abs(profileDF1.iloc[0,dColIndex])
-            dist2 = abs(profileDF1.iloc[-2,dColIndex])
+            topClass = "no top"
+            concave = "Convex"
+            shape = "Triangle"
+        else:  # The simplified profile has more than three profileDF, forming a polygon
+            slope1 = abs(profileDF1.iloc[0, sColIndex])
+            slope2 = abs(profileDF1.iloc[-2, sColIndex])
+            dist1 = abs(profileDF1.iloc[0, dColIndex])
+            dist2 = abs(profileDF1.iloc[-2, dColIndex])
             # to prevent divide by 0; changed on 20230419
             if (dist1 == 0) or (dist2 == 0):
                 sideSlope = (slope1 + slope2) / 2
-            else: 
-                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (dist1 + dist2)
+            else:
+                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (
+                    dist1 + dist2
+                )
             slClass = self.slopeClass(sideSlope)
             sList = []
             i = 1
-            while i < profileDF1.index.size-2:
-                s1 = profileDF1.iloc[i,sColIndex]
+            while i < profileDF1.index.size - 2:
+                s1 = profileDF1.iloc[i, sColIndex]
                 sList.append(s1)
                 i += 1
             # top slope equals the mean of the slopes of all non-side segments
-            topSlope = abs(sum(sList)/len(sList))
+            topSlope = abs(sum(sList) / len(sList))
             topClass = self.slopeClass(topSlope)
             # if the polygon has any angles larger than 180, it is considered as concave and irregular in shape
             if profileDF1.polygonAngle.max() > 180:
-                concave = 'Concave'
-                shape = 'Irregular'
+                concave = "Concave"
+                shape = "Irregular"
             else:
-                concave = 'Convex'
-                shape = 'Regular'
+                concave = "Convex"
+                shape = "Regular"
 
-        
         sideSlopeClass = slClass
         topSlopeClass = topClass
 
         if profileDF1.index.size == 2:
-            topDepth = 'NA'
-            height = 'NA'
-            length = 'NA'
+            topDepth = "NA"
+            height = "NA"
+            length = "NA"
         else:
             topDepth = str(abs(profileDF[depthCol].max()))
             height = str(profileDF[depthCol].max() - profileDF[depthCol].min())
-            length = str(self.calculateDistance(profileDF.iloc[-1,xColIndex],profileDF1.iloc[-1,yColIndex],profileDF1.iloc[0,xColIndex],profileDF1.iloc[0,yColIndex]))
-        
-        return shape,symmetry,concave,topSlopeClass,sideSlopeClass,topDepth,height,length                
-                    
+            length = str(
+                self.calculateDistance(
+                    profileDF.iloc[-1, xColIndex],
+                    profileDF1.iloc[-1, yColIndex],
+                    profileDF1.iloc[0, xColIndex],
+                    profileDF1.iloc[0, yColIndex],
+                )
+            )
+
+        return (
+            shape,
+            symmetry,
+            concave,
+            topSlopeClass,
+            sideSlopeClass,
+            topDepth,
+            height,
+            length,
+        )
+
     # This function calculates the profile attributes for the Bathymetric Low features
-    def calculate_profile_attributes_low(self,profileDF,depthCol,xCol,yCol,gap):
+    def calculate_profile_attributes_low(self, profileDF, depthCol, xCol, yCol, gap):
         # profileDF: profile data as a pandas dataframe
         # depthCol: the name of the depth column in the profileDF
         # xCol: the name of the x coordinate column in the profileDF
         # yCol: the name of the y coordinate column in the profileDF
         # gap: the maximum gap allowed between knick points to form the group
 
-                
         xColIndex = np.where(profileDF.columns.values == xCol)[0][0]
         yColIndex = np.where(profileDF.columns.values == yCol)[0][0]
         dColIndex = np.where(profileDF.columns.values == depthCol)[0][0]
         distL = []
-        x = profileDF.iloc[0,xColIndex]
-        y = profileDF.iloc[0,yColIndex]
+        x = profileDF.iloc[0, xColIndex]
+        y = profileDF.iloc[0, yColIndex]
         for i in profileDF.index:
-            x1 = profileDF.loc[i,xCol]
-            y1 = profileDF.loc[i,yCol]
-            dist = self.calculateDistance(x,y,x1,y1)
+            x1 = profileDF.loc[i, xCol]
+            y1 = profileDF.loc[i, yCol]
+            dist = self.calculateDistance(x, y, x1, y1)
             distL.append(dist)
-        profileDF.loc[:,'distance'] = distL
+        profileDF.loc[:, "distance"] = distL
         profileDF_copy = profileDF.copy(deep=True)
-        
+
         # initialise an id array
         idArr = np.arange(0)
         # calculate a slope threshold
-        slopeThreshold = abs(self.calculateSlopeThreshold(profileDF_copy,depthCol,xCol,yCol))
+        slopeThreshold = abs(
+            self.calculateSlopeThreshold(profileDF_copy, depthCol, xCol, yCol)
+        )
         # conduct the first round of profile analysis using the slopeThreshold
-        profileDF_copy,idArr1,idArr2,diffSlope_95 = self.profileAnalysis(profileDF_copy,depthCol,xCol,yCol,idArr,slopeThreshold)
+        profileDF_copy, idArr1, idArr2, diffSlope_95 = self.profileAnalysis(
+            profileDF_copy, depthCol, xCol, yCol, idArr, slopeThreshold
+        )
         # conduct the follwoing round(s) of profile analysis using the diffSlope_95 as the slopeThreshold
         # stop the loop when there is no element to be appended into the new array, thus the size of the input id array equals
         # the size of the updated id array
         while idArr2.size > idArr1.size:
-            profileDF_copy,idArr1,idArr2,dumy_95 = self.profileAnalysis(profileDF_copy,depthCol,xCol,yCol,idArr2,diffSlope_95)
-        
+            profileDF_copy, idArr1, idArr2, dumy_95 = self.profileAnalysis(
+                profileDF_copy, depthCol, xCol, yCol, idArr2, diffSlope_95
+            )
+
         # sort the id array
-        idArray=np.sort(idArr2)
-        idList=idArray.tolist()
-        i=0
+        idArray = np.sort(idArr2)
+        idList = idArray.tolist()
+        i = 0
         # find the ids groups
         while i < len(idList):
             if idArray.size > 0:
-                idList[i],idArray = self.findGroup(idArray,gap)
+                idList[i], idArray = self.findGroup(idArray, gap)
             i += 1
 
         i = 0
@@ -4292,9 +4966,9 @@ class helpers(object):
             if type(idList[i]) == list:
                 idGroups.append(idList[i])
             i += 1
-        
+
         # identify one single knick point from each id group (ie. knick group)
-        # the selected knick point represents the first (last) point in the knick group if the group 
+        # the selected knick point represents the first (last) point in the knick group if the group
         # is closer to the start (end) point of the profile
         # select key profileDF from the original profile data
         # the selected key profileDF include the first point, the last point, and the knick profileDF in between
@@ -4325,19 +4999,19 @@ class helpers(object):
             z2.append(z_1[indexX])
             i += 1
         # select the key profileDF from the profile data to form a simplied profile (profileDF1)
-        z2.insert(0,profileDF.index[0])
-        z2.insert(len(z2),profileDF.index[-1])
+        z2.insert(0, profileDF.index[0])
+        z2.insert(len(z2), profileDF.index[-1])
         profileDF1 = profileDF.loc[z2].copy()
         # add 'knick_point' column
-        profileDF.loc[:,'knick_point'] = profileDF.loc[:,'distance'] < 0
-        profileDF.loc[z2,'knick_point'] = True
-        
-        dList,slList = self.profileSlope(profileDF1,xCol,yCol,depthCol)
-        profileDF1.loc[:,'slope'] = slList
-        profileDF1.loc[:,'dist'] = dList
-        angleList = self.profileAngle(profileDF1,'slope')
-        profileDF1.loc[:,'polygonAngle'] = angleList
-        
+        profileDF.loc[:, "knick_point"] = profileDF.loc[:, "distance"] < 0
+        profileDF.loc[z2, "knick_point"] = True
+
+        dList, slList = self.profileSlope(profileDF1, xCol, yCol, depthCol)
+        profileDF1.loc[:, "slope"] = slList
+        profileDF1.loc[:, "dist"] = dList
+        angleList = self.profileAngle(profileDF1, "slope")
+        profileDF1.loc[:, "polygonAngle"] = angleList
+
         ## calculate profile attributes
         ## bottomSlopeClass: the slope class of the bottom of a bathymetic low; 'no bottom' indicates a triangle shape without bottom
         ## sideSlopeClass: the slope class of the sides of a bathmetric high
@@ -4348,79 +5022,97 @@ class helpers(object):
         ## height: the relief of the profile
         ## length: the length of the profile
 
-        sColIndex = np.where(profileDF1.columns.values == 'slope')[0][0]
+        sColIndex = np.where(profileDF1.columns.values == "slope")[0][0]
         # use profile skewness to determine shape symmetry
         # add 'numeric_only = True' option to deal with the new Pandas version (2023-04-06)
-        skewness = profileDF.skew(axis=0,numeric_only=True)[depthCol]
+        skewness = profileDF.skew(axis=0, numeric_only=True)[depthCol]
         if abs(skewness) < 0.2:
             symmetry = "Symmetric"
         else:
             symmetry = "Asymmetric"
 
-         
-        if profileDF1.index.size == 2: # The simplified profile has only two points      
-            shape = 'Flat'
-            symmetry = 'NA'
-            bottomClass = 'flat'
-            concave = 'NA'
-            slClass = 'NA' 
-        elif profileDF1.index.size == 3:  # The simplified profile has only three profileDF, forming a triangle
+        if profileDF1.index.size == 2:  # The simplified profile has only two points
+            shape = "Flat"
+            symmetry = "NA"
+            bottomClass = "flat"
+            concave = "NA"
+            slClass = "NA"
+        elif (
+            profileDF1.index.size == 3
+        ):  # The simplified profile has only three profileDF, forming a triangle
             # calculate weighted averaged side slope
-            slope1 = abs(profileDF1.iloc[0,sColIndex])
-            slope2 = abs(profileDF1.iloc[1,sColIndex])
-            dist1 = abs(profileDF1.iloc[0,dColIndex])
-            dist2 = abs(profileDF1.iloc[1,dColIndex])
+            slope1 = abs(profileDF1.iloc[0, sColIndex])
+            slope2 = abs(profileDF1.iloc[1, sColIndex])
+            dist1 = abs(profileDF1.iloc[0, dColIndex])
+            dist2 = abs(profileDF1.iloc[1, dColIndex])
             # to prevent divide by 0; changed on 2023-04-19
             if (dist1 == 0) or (dist2 == 0):
                 sideSlope = (slope1 + slope2) / 2
-            else: 
-                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (dist1 + dist2)
+            else:
+                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (
+                    dist1 + dist2
+                )
             slClass = self.slopeClass(sideSlope)
-            bottomClass = 'no bottom'
-            concave = 'Convex'
-            shape = 'Triangle'
-        else: # The simplified profile has more than three profileDF, forming a polygon
-            slope1 = abs(profileDF1.iloc[0,sColIndex])
-            slope2 = abs(profileDF1.iloc[-2,sColIndex])
-            dist1 = abs(profileDF1.iloc[0,dColIndex])
-            dist2 = abs(profileDF1.iloc[-2,dColIndex])
+            bottomClass = "no bottom"
+            concave = "Convex"
+            shape = "Triangle"
+        else:  # The simplified profile has more than three profileDF, forming a polygon
+            slope1 = abs(profileDF1.iloc[0, sColIndex])
+            slope2 = abs(profileDF1.iloc[-2, sColIndex])
+            dist1 = abs(profileDF1.iloc[0, dColIndex])
+            dist2 = abs(profileDF1.iloc[-2, dColIndex])
             # to prevent divide by 0; changed on 2023-04-19
             if (dist1 == 0) or (dist2 == 0):
                 sideSlope = (slope1 + slope2) / 2
-            else: 
-                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (dist1 + dist2)
+            else:
+                sideSlope = slope1 * dist1 / (dist1 + dist2) + slope2 * dist2 / (
+                    dist1 + dist2
+                )
             slClass = self.slopeClass(sideSlope)
             sList = []
             i = 1
-            while i < profileDF1.index.size-2:
-                s1 = profileDF1.iloc[i,sColIndex]
+            while i < profileDF1.index.size - 2:
+                s1 = profileDF1.iloc[i, sColIndex]
                 sList.append(s1)
                 i += 1
             # top slope equals the mean of the slopes of all non-side segments
-            bottomSlope = abs(sum(sList)/len(sList))
+            bottomSlope = abs(sum(sList) / len(sList))
             bottomClass = self.slopeClass(bottomSlope)
             # if the polygon has any angles larger than 180, it is considered as concave and irregular in shape
             if profileDF1.polygonAngle.max() > 180:
-                concave = 'Concave'
-                shape = 'Irregular'
+                concave = "Concave"
+                shape = "Irregular"
             else:
-                concave = 'Convex'
-                shape = 'Regular'
+                concave = "Convex"
+                shape = "Regular"
 
-        
         sideSlopeClass = slClass
         bottomSlopeClass = bottomClass
 
         if profileDF1.index.size == 2:
-            bottomDepth = 'NA'
-            height = 'NA'
-            length = 'NA'
+            bottomDepth = "NA"
+            height = "NA"
+            length = "NA"
         else:
             # fix bottomDepth, using .min() instead of .max() (2023-04-19)
             bottomDepth = str(abs(profileDF[depthCol].min()))
             height = str(profileDF[depthCol].max() - profileDF[depthCol].min())
-            length = str(self.calculateDistance(profileDF.iloc[-1,xColIndex],profileDF1.iloc[-1,yColIndex],profileDF1.iloc[0,xColIndex],profileDF1.iloc[0,yColIndex]))
-            
-        return shape,symmetry,concave,bottomSlopeClass,sideSlopeClass,bottomDepth,height,length   
-                    
-                    
+            length = str(
+                self.calculateDistance(
+                    profileDF.iloc[-1, xColIndex],
+                    profileDF1.iloc[-1, yColIndex],
+                    profileDF1.iloc[0, xColIndex],
+                    profileDF1.iloc[0, yColIndex],
+                )
+            )
+
+        return (
+            shape,
+            symmetry,
+            concave,
+            bottomSlopeClass,
+            sideSlopeClass,
+            bottomDepth,
+            height,
+            length,
+        )

--- a/Tools/BathymetricHigh.pyt
+++ b/Tools/BathymetricHigh.pyt
@@ -5,17 +5,17 @@
 #### Python version: 3+
 #### ArcGIS Pro: 2.6.4 and above
 
+import math
+import warnings
+from datetime import datetime
+
 import arcpy
+import numpy as np
 from arcpy import env
 from arcpy.sa import *
-import os
-import math
-import numpy as np
-import warnings
-from datetime import datetime 
 
 
-class Toolbox(object):
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -24,10 +24,11 @@ class Toolbox(object):
 
         # List of tool classes associated with this toolbox
         # There are three tools in this toolset used to map Bathymetric High features.
-        self.tools = [TPITool,TPI_LMITool,Openness_High_Tool]
+        self.tools = [TPITool, TPI_LMITool, Openness_High_Tool]
+
 
 # TPITool uses Topographic Position Index (TPI) technique to map Bathymetric High features
-class TPITool(object):
+class TPITool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "TPI Tool Bathymetric High"
@@ -43,7 +44,8 @@ class TPITool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -51,7 +53,8 @@ class TPITool(object):
             name="tpiRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -59,7 +62,8 @@ class TPITool(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -67,24 +71,27 @@ class TPITool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")
-               
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="TPI Circle Radius (unit: cell)",
             name="tpiRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 3
-        
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="TPI STD Scale",
             name="tpiSTDScale",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 1.0
 
         # seventh parameter
@@ -93,10 +100,11 @@ class TPITool(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param6.defaultEnvironmentName = "workspace"
-        
-        parameters = [param0, param1, param2, param3, param4, param5,param6]
+
+        parameters = [param0, param1, param2, param3, param4, param5, param6]
         return parameters
 
     def isLicensed(self):
@@ -107,7 +115,6 @@ class TPITool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -128,7 +135,7 @@ class TPITool(object):
         tempWS = parameters[6].valueAsText
         # enable the helper functions
         helper = helpers()
-                                  
+
         bathyRas = helper.convert_backslach_forwardslach(bathyRas)
         tpiRas = helper.convert_backslach_forwardslach(tpiRas)
         outFeat = helper.convert_backslach_forwardslach(outFeat)
@@ -137,7 +144,7 @@ class TPITool(object):
         # In this case, the full path needs to be obtained from the map layer
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
@@ -145,60 +152,86 @@ class TPITool(object):
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the output TPI grid must be in a correct format
         if tpiRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = tpiRas[0:tpiRas.rfind("/")]
-        workspaceName2 = outFeat[0:outFeat.rfind("/")]
-        
+
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = tpiRas[0 : tpiRas.rfind("/")]
+        workspaceName2 = outFeat[0 : outFeat.rfind("/")]
+
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        # waterproof some unusal errors       
+        areaUnit = areaThreshold.split(" ")[1]
+        # waterproof some unusal errors
         if tpiRas == outFeat:
-            messages.addErrorMessage("The output TPI raster and output Featureclass cannot have the same name in the same workspace!")
+            messages.addErrorMessage(
+                "The output TPI raster and output Featureclass cannot have the same name in the same workspace!"
+            )
             raise arcpy.ExecuteError
-            
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2):
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
             raise arcpy.ExecuteError
-        
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-  
 
-        arcpy.env.workspace=workspaceName
-        
+        arcpy.env.workspace = workspaceName
+
         # call the helper function to calculate TPI and generate output Bathymetric High features
-        helper.TPI_Tool(tempWS,bathyRas,tpiRas,outFeat,areaThresholdValue,areaUnit,tpiRadius,tpiSTDScale)
-        
+        helper.TPI_Tool(
+            tempWS,
+            bathyRas,
+            tpiRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            tpiRadius,
+            tpiSTDScale,
+        )
+
         return
 
 
-# TPI_LMITool uses Topographic Position Index (TPI) technique and Local Moran I (LMI) technique to map Bathymetric High features    
-class TPI_LMITool(object):
+# TPI_LMITool uses Topographic Position Index (TPI) technique and Local Moran I (LMI) technique to map Bathymetric High features
+class TPI_LMITool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "TPI LMI Tool Bathymetric High"
@@ -214,7 +247,8 @@ class TPI_LMITool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -222,7 +256,8 @@ class TPI_LMITool(object):
             name="tpiRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -230,7 +265,8 @@ class TPI_LMITool(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -238,24 +274,27 @@ class TPI_LMITool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")       
-        
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="TPI Circle Radius (unit: cell)",
             name="tpiRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 3
-        
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="TPI STD Scale Large",
             name="tpiSTDScaleLarge",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 1.0
 
         # seventh parameter
@@ -264,7 +303,8 @@ class TPI_LMITool(object):
             name="tpiSTDScaleSmall",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 0.5
 
         # eighth parameter
@@ -273,8 +313,9 @@ class TPI_LMITool(object):
             name="lmiWeightFile",
             datatype="DEFile",
             parameterType="Required",
-            direction="Input")
-        param7.filter.list = ['txt']
+            direction="Input",
+        )
+        param7.filter.list = ["txt"]
 
         # nineth parameter
         param8 = arcpy.Parameter(
@@ -282,7 +323,8 @@ class TPI_LMITool(object):
             name="lmiSTDScale",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param8.value = 1.0
 
         # tenth parameter
@@ -291,11 +333,22 @@ class TPI_LMITool(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param9.defaultEnvironmentName = "workspace"
- 
-        
-        parameters = [param0, param1, param2, param3, param4, param5, param6, param7, param8, param9]
+
+        parameters = [
+            param0,
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6,
+            param7,
+            param8,
+            param9,
+        ]
         return parameters
 
     def isLicensed(self):
@@ -306,7 +359,6 @@ class TPI_LMITool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -317,7 +369,7 @@ class TPI_LMITool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         bathyRas = parameters[0].valueAsText
         tpiRas = parameters[1].valueAsText
         outFeat = parameters[2].valueAsText
@@ -338,7 +390,7 @@ class TPI_LMITool(object):
 
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
@@ -347,61 +399,94 @@ class TPI_LMITool(object):
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the output TPI grid must be in a correct format
         if tpiRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = tpiRas[0:tpiRas.rfind("/")]
-        workspaceName2 = outFeat[0:outFeat.rfind("/")]
+
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = tpiRas[0 : tpiRas.rfind("/")]
+        workspaceName2 = outFeat[0 : outFeat.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        # waterproof some unusal errors       
+        areaUnit = areaThreshold.split(" ")[1]
+        # waterproof some unusal errors
         if tpiRas == outFeat:
-            messages.addErrorMessage("The output TPI raster and output Featureclass cannot have the same name in the same workspace!")
+            messages.addErrorMessage(
+                "The output TPI raster and output Featureclass cannot have the same name in the same workspace!"
+            )
             raise arcpy.ExecuteError
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2):
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
             raise arcpy.ExecuteError
-        
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-  
 
-        arcpy.env.workspace=workspaceName
+        arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to calculate TPI and LMI and generate Bathymetric High features
-        helper.TPI_LMI_Tool(tempWS,bathyRas,tpiRas,outFeat,areaThresholdValue,areaUnit,tpiRadius,tpiSTDScaleLarge,tpiSTDScaleSmall,lmiWeightFile,lmiSTDScale)
-        
+        helper.TPI_LMI_Tool(
+            tempWS,
+            bathyRas,
+            tpiRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            tpiRadius,
+            tpiSTDScaleLarge,
+            tpiSTDScaleSmall,
+            lmiWeightFile,
+            lmiSTDScale,
+        )
+
         return
+
+
 # Openness_High_Tool uses Openness technique to map Bathymetric High features
-class Openness_High_Tool(object):
+class Openness_High_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Openness Tool Bathymetric High"
-        self.description = "Cacluate Negative Openness and generate an output Featureclass"
+        self.description = (
+            "Cacluate Negative Openness and generate an output Featureclass"
+        )
         self.canRunInBackground = False
 
     def getParameterInfo(self):
@@ -413,7 +498,8 @@ class Openness_High_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -421,7 +507,8 @@ class Openness_High_Tool(object):
             name="noRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -429,7 +516,8 @@ class Openness_High_Tool(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -437,24 +525,27 @@ class Openness_High_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")       
-        
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="Openness Circle Radius (unit: cell)",
             name="noRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 3
-        
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="NO STD Scale Large",
             name="noSTDScaleLarge",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 2.0
 
         # seventh parameter
@@ -463,7 +554,8 @@ class Openness_High_Tool(object):
             name="noSTDScaleSmall",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 1.0
 
         # eighth parameter
@@ -472,10 +564,10 @@ class Openness_High_Tool(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param7.defaultEnvironmentName = "workspace"
 
-        
         parameters = [param0, param1, param2, param3, param4, param5, param6, param7]
         return parameters
 
@@ -487,7 +579,6 @@ class Openness_High_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -508,7 +599,7 @@ class Openness_High_Tool(object):
         noSTDScaleLarge = parameters[5].valueAsText
         noSTDScaleSmall = parameters[6].valueAsText
         tempWS = parameters[7].valueAsText
- 
+
         bathyRas = helper.convert_backslach_forwardslach(bathyRas)
         noRas = helper.convert_backslach_forwardslach(noRas)
         outFeat = helper.convert_backslach_forwardslach(outFeat)
@@ -516,123 +607,152 @@ class Openness_High_Tool(object):
 
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
                         bathyRas = helper.convert_backslach_forwardslach(lyr.dataSource)
-      
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the output TPI grid must be in a correct format
         if noRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output NO raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output NO raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = noRas[0:noRas.rfind("/")]
-        workspaceName2 = outFeat[0:outFeat.rfind("/")]
+
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = noRas[0 : noRas.rfind("/")]
+        workspaceName2 = outFeat[0 : outFeat.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        # waterproof some unusal errors       
+        areaUnit = areaThreshold.split(" ")[1]
+        # waterproof some unusal errors
         if noRas == outFeat:
-            messages.addErrorMessage("The output Negative Openness raster and output Featureclass cannot have the same name in the same workspace!")
+            messages.addErrorMessage(
+                "The output Negative Openness raster and output Featureclass cannot have the same name in the same workspace!"
+            )
             raise arcpy.ExecuteError
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2):
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
             raise arcpy.ExecuteError
-        
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
-            raise arcpy.ExecuteError  
+            raise arcpy.ExecuteError
 
         arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to calculate openness and generate Bathymetric High features
-        helper.opennessHigh(tempWS,bathyRas,noRas,outFeat,areaThresholdValue,areaUnit,noRadius,noSTDScaleLarge,noSTDScaleSmall,messages)
-        
-        return                              
-        
+        helper.opennessHigh(
+            tempWS,
+            bathyRas,
+            noRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            noRadius,
+            noSTDScaleLarge,
+            noSTDScaleSmall,
+            messages,
+        )
+
+        return
+
+
 # helper functions are defined below
-class helpers(object):
+class helpers:
     # This function converts comma decimal separator (e.g., European standard) to dot (e.g.,US, UK and Australian standard)
-    def convertDecimalSeparator(self,inText):
+    def convertDecimalSeparator(self, inText):
         # inText: input string representing a decimal number
-        textList = inText.split(',')
-        inText1 = textList[0] + '.' + textList[1]
+        textList = inText.split(",")
+        inText1 = textList[0] + "." + textList[1]
         return inText1
 
-    
     # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
+    def convert_backslach_forwardslach(self, inText):
         # inText: input path
-        
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
 
-        inText = inText.replace('\\','/')
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
+
+        inText = inText.replace("\\", "/")
         return inText
-    
+
     # This function calculate TPI values from a bathymetry grid
-    def calculateTPI(self,bathy,radius,tpiRas):
+    def calculateTPI(self, bathy, radius, tpiRas):
         # bathy: input bathymetry grid
         # radius: the input radius value of a circle window
         # tpiRas: output TPI grid
-        
+
         time1 = datetime.now()
-        neighborhood = NbrCircle(radius,"CELL")
-        outFocal = FocalStatistics(bathy,neighborhood,"MEAN","DATA")
+        neighborhood = NbrCircle(radius, "CELL")
+        outFocal = FocalStatistics(bathy, neighborhood, "MEAN", "DATA")
         # TPI equals to the difference between the value of the centre cell and the mean value of its neighbourhood
         outMinus = Minus(bathy, outFocal)
         outMinus.save(tpiRas)
         arcpy.AddMessage("TPI is done")
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to generate TPI.")
+        arcpy.AddMessage("took " + str(diff) + " to generate TPI.")
         return
 
     # This function selects part of the raster based on a threshold value
-    def selectRaster(self,inRas,outRas,threshold,sign,value = 1):
+    def selectRaster(self, inRas, outRas, threshold, sign, value=1):
         # inRas: input raster
         # outRas: output raster
         # threshold: input threshold value used to select the inRas
         # sign: sign as part of the selection condition
         # value: the new raster value assigned to the part of the raster that satisfies the condition
-        
+
         if sign == ">=":
-            conDo = Con((Raster(inRas) >= threshold),value)
+            conDo = Con((Raster(inRas) >= threshold), value)
         elif sign == "<=":
-            conDo = Con((Raster(inRas) <= threshold),value)
+            conDo = Con((Raster(inRas) <= threshold), value)
         conDo.save(outRas)
 
     # This function calculates LMI values from the bathymetry grid
-    def calculateLMI(self,bathy,weightFile,lmiRas):
+    def calculateLMI(self, bathy, weightFile, lmiRas):
         # bathy: input bathymetry grid
         # weightFile: the path to the weight kernal file defining a neighbourhood
         # lmiRas: output LMI grid
@@ -640,27 +760,32 @@ class helpers(object):
         # spatial mean of the bathymetry grid
         meanResult = arcpy.GetRasterProperties_management(bathy, "MEAN")
         meanText = meanResult.getOutput(0)
-        if meanText.find(',') > 0:
+        if meanText.find(",") > 0:
             meanText = self.convertDecimalSeparator(meanText)
         # spatial standard deviation of the bathymetry grid
         stdResult = arcpy.GetRasterProperties_management(bathy, "STD")
         stdText = stdResult.getOutput(0)
-        if stdText.find(',') > 0:
+        if stdText.find(",") > 0:
             stdText = self.convertDecimalSeparator(stdText)
         NbrWeight1 = NbrWeight(weightFile)
         # the LMI algorithm
-        outFocal = FocalStatistics(Minus(bathy, float(meanText)), NbrWeight1, "SUM", "DATA")
-        outRas = Times(Divide(Minus(bathy, float(meanText)),Square(float(stdText))),outFocal)
+        outFocal = FocalStatistics(
+            Minus(bathy, float(meanText)), NbrWeight1, "SUM", "DATA"
+        )
+        outRas = Times(
+            Divide(Minus(bathy, float(meanText)), Square(float(stdText))), outFocal
+        )
         outRas.save(lmiRas)
         arcpy.AddMessage("local moran i done")
         return
+
     # This function extract input features from the bathymetry grid
-    def extractMask(self,tempWS,bathy,inFeat,STDScale = 0):
+    def extractMask(self, tempWS, bathy, inFeat, STDScale=0):
         # tempWS: temporary workspace to store temporary data
         # bathy: input bathymetry grid
         # inFeat: input features
         # STDScale: threshold value
-        
+
         cursor = arcpy.SearchCursor(inFeat)
         # all extracted areas are to be appended and merged later
         inFeats = []
@@ -669,14 +794,14 @@ class helpers(object):
         for row in cursor:
             polyID = row.getValue("OBJECTID")
             idV = row.getValue("Id")
-            arcpy.AddMessage(str(polyID) + ';' + str(idV))
+            arcpy.AddMessage(str(polyID) + ";" + str(idV))
             whereClause = '"OBJECTID" = ' + str(polyID)
-            arcpy.Select_analysis(inFeat,temp1,whereClause)
+            arcpy.Select_analysis(inFeat, temp1, whereClause)
             extractedRas = tempWS + "/" + "extract_" + str(polyID)
             if arcpy.Exists(extractedRas):
                 arcpy.Delete_management(extractedRas)
             # extract bathymetry grid for the area covered by the input feature
-            outMask1 = ExtractByMask(bathy,temp1)
+            outMask1 = ExtractByMask(bathy, temp1)
             outMask1.save(extractedRas)
             # select proportion of the extracted raster with a condition (.= Threshold)
             extractedRas1 = tempWS + "/" + "extract_" + str(polyID) + "_1"
@@ -684,44 +809,52 @@ class helpers(object):
                 arcpy.Delete_management(extractedRas1)
             STDResult = arcpy.GetRasterProperties_management(extractedRas, "STD")
             stdText = STDResult.getOutput(0)
-            if stdText.find(',') > 0:
+            if stdText.find(",") > 0:
                 stdText = self.convertDecimalSeparator(stdText)
             STD = float(stdText)
             MEANResult = arcpy.GetRasterProperties_management(extractedRas, "MEAN")
             meanText = MEANResult.getOutput(0)
-            if meanText.find(',') > 0:
+            if meanText.find(",") > 0:
                 meanText = self.convertDecimalSeparator(meanText)
             Mean = float(meanText)
             MAXResult = arcpy.GetRasterProperties_management(extractedRas, "MAXIMUM")
             maxText = MAXResult.getOutput(0)
-            if maxText.find(',') > 0:
+            if maxText.find(",") > 0:
                 maxText = self.convertDecimalSeparator(maxText)
-            Max = float(maxText)            
+            Max = float(maxText)
 
-            Threshold = Mean + STDScale*STD
+            Threshold = Mean + STDScale * STD
             if Threshold >= Max:
-                arcpy.AddMessage("You must provide a threhold smaller than the maximum value, reset to the mean value")
+                arcpy.AddMessage(
+                    "You must provide a threhold smaller than the maximum value, reset to the mean value"
+                )
                 Threshold = Mean
-            self.selectRaster(extractedRas,extractedRas1,Threshold,">=",idV) 
-       
+            self.selectRaster(extractedRas, extractedRas1, Threshold, ">=", idV)
+
             # convert selected areas to polygons
             extractedFeat = extractedRas1 + "_poly"
-            arcpy.RasterToPolygon_conversion(extractedRas1, extractedFeat, "NO_SIMPLIFY", "VALUE","MULTIPLE_OUTER_PART")
+            arcpy.RasterToPolygon_conversion(
+                extractedRas1,
+                extractedFeat,
+                "NO_SIMPLIFY",
+                "VALUE",
+                "MULTIPLE_OUTER_PART",
+            )
             inFeats.append(extractedFeat)
             arcpy.Delete_management(temp1)
             arcpy.Delete_management(extractedRas)
             arcpy.Delete_management(extractedRas1)
-        del row, cursor    
+        del row, cursor
 
         return inFeats
 
     # This function deletes all intermediate data items
-    def deleteDataItems(self,inDataList):
+    def deleteDataItems(self, inDataList):
         # inDataList: a list of data items to be deleted
-        
+
         if len(inDataList) == 0:
             arcpy.AddMessage("no data item in the list")
-            
+
         else:
             for item in inDataList:
                 arcpy.AddMessage("Deleting " + item)
@@ -729,45 +862,42 @@ class helpers(object):
         return
 
     # This function deletes all unnecessary fields from the input featureclass
-    def deleteFields(self,inFeat):
+    def deleteFields(self, inFeat):
         # inFeat: input featureclass
-        fields = arcpy.ListFields(inFeat)        
+        fields = arcpy.ListFields(inFeat)
         fieldList = []
         for field in fields:
             if not field.required:
                 fieldList.append(field.name)
-        arcpy.DeleteField_management(inFeat,fieldList)        
-            
-        
-    
+        arcpy.DeleteField_management(inFeat, fieldList)
+
     # This function adds a featID field with unique ID values
-    def addIDField(self,inFeat,fieldName):
-        # inFeat: input featureclass (or table)       
-        # fieldName: the field in the inFeat to be calculated from the joinFeat        
-        
+    def addIDField(self, inFeat, fieldName):
+        # inFeat: input featureclass (or table)
+        # fieldName: the field in the inFeat to be calculated from the joinFeat
+
         fieldType = "LONG"
         fieldPrecision = 15
-        
 
         fields = arcpy.ListFields(inFeat)
         field_names = [f.name for f in fields]
-        
+
         if fieldName in field_names:
             arcpy.AddMessage(fieldName + " exists and will be recalculated")
         else:
-            arcpy.AddField_management(inFeat,fieldName,fieldType,fieldPrecision)
+            arcpy.AddField_management(inFeat, fieldName, fieldType, fieldPrecision)
 
         expression = "!OBJECTID!"
 
         arcpy.CalculateField_management(inFeat, fieldName, expression, "PYTHON_9.3")
-        
+
         arcpy.AddMessage(fieldName + " added and calculated")
         return
 
     # This function calculates a converter value for the input area unit. The base unit is "SquareKilometers".
-    def areaUnitConverter(self,inAreaUnit):
+    def areaUnitConverter(self, inAreaUnit):
         # inAreaUnit: input Area Unit
-        
+
         if inAreaUnit == "Acres":
             converter = 0.00404686
         elif inAreaUnit == "Ares":
@@ -791,19 +921,21 @@ class helpers(object):
         elif inAreaUnit == "SquareMillimeters":
             converter = 0.000000000001
         elif inAreaUnit == "SquareYards":
-            converter = 0.00000083613       
+            converter = 0.00000083613
 
         return converter
 
     # This function calculates positive or negative openness value from the batymetry grid
-    def calculateOpenness(self,bathyRas,radius,opennessParameter,outRas,tempWS,messages):
+    def calculateOpenness(
+        self, bathyRas, radius, opennessParameter, outRas, tempWS, messages
+    ):
         # bathyRas: input bathymetry grid
         # radius: radius value of the analysis window
         # opennessParameter: determine whether to calculate positive or negative openness
         # outRas: output openness grid
         # tempWS: temporary workspace
         # messages: to handle error messages
-        
+
         ## most of the codes are taken from the "Openness" tool in the "ArcGeomorphometry Tools" python toolbox
         ## with the following modifications: 1) the analysis radius (window size) now accepts all positive integer values not limited to odd numbers only
         ## 2) the border areas are now processed properly instead of being left blank
@@ -812,7 +944,7 @@ class helpers(object):
         time1 = datetime.now()
         radius = int(radius)
         # the radius in the diagonal directions
-        radius1 = int(np.round(radius/np.sqrt(2)))
+        radius1 = int(np.round(radius / np.sqrt(2)))
 
         # Describe input raster
         descData = arcpy.Describe(bathyRas)
@@ -826,16 +958,18 @@ class helpers(object):
 
         spatialReference = descData.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage('    *** Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required. ***')
+            messages.addErrorMessage(
+                "    *** Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required. ***"
+            )
             raise arcpy.ExecuteError
-        pnt = arcpy.Point(xmin,ymin)
+        pnt = arcpy.Point(xmin, ymin)
 
         # Load DEM into numpy float32 array
         rasterDEMArray = arcpy.RasterToNumPyArray(bathyRas)
 
         # Check window size
         if radius > rasterDEMArray.shape[-1]:
-            messages.addErrorMessage('    *** Analysis window is too long. ***')
+            messages.addErrorMessage("    *** Analysis window is too long. ***")
             raise arcpy.ExecuteError
 
         #   calculate elevation angles within roughly circular search window (clockwise from N=0º)
@@ -843,130 +977,191 @@ class helpers(object):
 
         outArray = np.zeros(outShape, dtype=np.float32)
         # the new array extends the loaded DEM array with a width of the radius from all four borders, so that the border areas of the loaded DEM can be processed properly
-        rasterDEMArray1 = np.arange((rasterDEMArray.shape[0]+2*radius)*(rasterDEMArray.shape[1]+2*radius)).reshape(rasterDEMArray.shape[0]+2*radius,rasterDEMArray.shape[1]+2*radius)
-        rasterDEMArray1 = np.zeros_like(rasterDEMArray1,dtype=float)
+        rasterDEMArray1 = np.arange(
+            (rasterDEMArray.shape[0] + 2 * radius)
+            * (rasterDEMArray.shape[1] + 2 * radius)
+        ).reshape(
+            rasterDEMArray.shape[0] + 2 * radius, rasterDEMArray.shape[1] + 2 * radius
+        )
+        rasterDEMArray1 = np.zeros_like(rasterDEMArray1, dtype=float)
         rasterDEMArray1[:] = np.nan
-        rasterDEMArray1[radius:rasterDEMArray.shape[0]+radius,radius:rasterDEMArray.shape[1]+radius]=rasterDEMArray
-        del(rasterDEMArray) # to release memory
+        rasterDEMArray1[
+            radius : rasterDEMArray.shape[0] + radius,
+            radius : rasterDEMArray.shape[1] + radius,
+        ] = rasterDEMArray
+        del rasterDEMArray  # to release memory
         #   set temporal arrays
         tempArray = np.zeros_like(outArray)
-        # arrayList holds the temporal arrays, so that we can calculate np.nanmean() 
+        # arrayList holds the temporal arrays, so that we can calculate np.nanmean()
         arrayList = []
-        shiftsList = [(x,y) for x in range(-radius,radius+1) for y in range(-radius,radius+1)]
+        shiftsList = [
+            (x, y)
+            for x in range(-radius, radius + 1)
+            for y in range(-radius, radius + 1)
+        ]
         #   calculate elevation angles within roughly circular search window (clockwise from N=0º)
         for direction in range(0, 360, 45):
             if direction == 0:
-                shiftsListD = filter (lambda arr: arr[0] < 0 and arr[1] == 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] < 0 and arr[1] == 0, shiftsList)
             elif direction == 45:
-                shiftsListD = filter (lambda arr: arr[1] < radius1+1 and arr[0] == -arr[1] and arr[1] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[1] < radius1 + 1
+                    and arr[0] == -arr[1]
+                    and arr[1] > 0,
+                    shiftsList,
+                )
             elif direction == 90:
-                shiftsListD = filter (lambda arr: arr[0] == 0 and arr[1] > 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] == 0 and arr[1] > 0, shiftsList)
             elif direction == 135:
-                shiftsListD = filter (lambda arr: arr[1] < radius1+1 and arr[0] == arr[1] and arr[0] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[1] < radius1 + 1
+                    and arr[0] == arr[1]
+                    and arr[0] > 0,
+                    shiftsList,
+                )
             elif direction == 180:
-                shiftsListD = filter (lambda arr: arr[0] > 0 and arr[1] == 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] > 0 and arr[1] == 0, shiftsList)
             elif direction == 225:
-                shiftsListD = filter (lambda arr: arr[0] < radius1+1 and arr[0] == -arr[1] and arr[0] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[0] < radius1 + 1
+                    and arr[0] == -arr[1]
+                    and arr[0] > 0,
+                    shiftsList,
+                )
             elif direction == 270:
-                shiftsListD = filter (lambda arr: arr[0] == 0 and arr[1] < 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] == 0 and arr[1] < 0, shiftsList)
             elif direction == 315:
-                shiftsListD = filter (lambda arr: -arr[1] < radius1+1 and arr[0] == arr[1] and arr[0] < 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: -arr[1] < radius1 + 1
+                    and arr[0] == arr[1]
+                    and arr[0] < 0,
+                    shiftsList,
+                )
 
-            if opennessParameter == 'positiveOpenness': # calculate positive openness
+            if opennessParameter == "positiveOpenness":  # calculate positive openness
                 tempArray.fill(-9999.9)
-                for dx,dy in shiftsListD:           
-                    xstop = -radius+dx or None
-                    ystop = -radius+dy or None
-                    angleArray = (rasterDEMArray1[radius+dx:xstop, radius+dy:ystop] - rasterDEMArray1[radius:-radius, radius:-radius]) / (math.hypot(dx, dy) * cellSize)
+                for dx, dy in shiftsListD:
+                    xstop = -radius + dx or None
+                    ystop = -radius + dy or None
+                    angleArray = (
+                        rasterDEMArray1[radius + dx : xstop, radius + dy : ystop]
+                        - rasterDEMArray1[radius:-radius, radius:-radius]
+                    ) / (math.hypot(dx, dy) * cellSize)
                     angleArray[np.isnan(angleArray)] = -999999.9
                     tempArray = np.maximum(tempArray, angleArray)
-                tempArray = np.where(tempArray < -9999,np.nan,tempArray)
+                tempArray = np.where(tempArray < -9999, np.nan, tempArray)
                 arrayList.append(90 - np.degrees(np.arctan(tempArray)))
-            elif opennessParameter == 'negativeOpenness': # calculate negative openness
+            elif opennessParameter == "negativeOpenness":  # calculate negative openness
                 tempArray.fill(9999.9)
-                for dx,dy in shiftsListD:
-                    xstop = -radius+dx or None
-                    ystop = -radius+dy or None
-                    angleArray = (rasterDEMArray1[radius+dx:xstop, radius+dy:ystop] - rasterDEMArray1[radius:-radius, radius:-radius]) / (math.hypot(dx, dy) * cellSize)
+                for dx, dy in shiftsListD:
+                    xstop = -radius + dx or None
+                    ystop = -radius + dy or None
+                    angleArray = (
+                        rasterDEMArray1[radius + dx : xstop, radius + dy : ystop]
+                        - rasterDEMArray1[radius:-radius, radius:-radius]
+                    ) / (math.hypot(dx, dy) * cellSize)
                     angleArray[np.isnan(angleArray)] = -999999.9
                     tempArray = np.minimum(tempArray, angleArray)
-                tempArray = np.where(tempArray < -9999,np.nan,tempArray)
+                tempArray = np.where(tempArray < -9999, np.nan, tempArray)
                 arrayList.append(90 + np.degrees(np.arctan(tempArray)))
-        del(rasterDEMArray1) # to release memory
-        del(tempArray) # to release memory
-        
+        del rasterDEMArray1  # to release memory
+        del tempArray  # to release memory
+
         # np.stack() requires numpy version 1.10.0 or higher
         stacked_array = np.stack(arrayList)
         with warnings.catch_warnings():
             # ignore runtime warning
-            warnings.simplefilter("ignore",category=RuntimeWarning)
-            outArray = np.nanmean(stacked_array,axis=0)
-        
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            outArray = np.nanmean(stacked_array, axis=0)
+
         # Create new output calculated raster, set spatial coordinates and save
         # if the raster is more than 5000 cells in either X or Y directions, split the raster into blocks
         blocksize = 5000
         if (width <= blocksize) and (height <= blocksize):
-            newRaster = arcpy.NumPyArrayToRaster(outArray,pnt,cellSize,cellSize,-9999)
-            if spatialReference.name != 'Unknown':
+            newRaster = arcpy.NumPyArrayToRaster(
+                outArray, pnt, cellSize, cellSize, -9999
+            )
+            if spatialReference.name != "Unknown":
                 arcpy.DefineProjection_management(newRaster, spatialReference)
             # Set nodata where nodata in the input DEM
-            newRaster = SetNull(IsNull(bathyRas),newRaster)
+            newRaster = SetNull(IsNull(bathyRas), newRaster)
             newRaster.save(outRas)
-            del(outArray)
-        else:            
+            del outArray
+        else:
             itemList = []
             xList = []
             yList = []
-            for x in range(0,width,blocksize):
+            for x in range(0, width, blocksize):
                 xList.append(x)
-            for y in range(0,height,blocksize):
+            for y in range(0, height, blocksize):
                 yList.append(y)
             xList.append(width)
             yList.append(height)
 
             i = 0
-            j = len(yList)-1
+            j = len(yList) - 1
             k = 0
-            while i < len(xList)-1:
+            while i < len(xList) - 1:
                 while j > 0:
-                    arr = outArray[yList[j-1]:yList[j],xList[i]:xList[i+1]]
+                    arr = outArray[yList[j - 1] : yList[j], xList[i] : xList[i + 1]]
                     hh = arr.shape[0]
                     ww = arr.shape[1]
-                    pnt = arcpy.Point(xmin,ymin)
-                    newRaster = arcpy.NumPyArrayToRaster(arr,pnt,cellSize,cellSize,-9999)
-                    ras = tempWS + '/' + 'tempRas' + str(k)
+                    pnt = arcpy.Point(xmin, ymin)
+                    newRaster = arcpy.NumPyArrayToRaster(
+                        arr, pnt, cellSize, cellSize, -9999
+                    )
+                    ras = tempWS + "/" + "tempRas" + str(k)
                     itemList.append(ras)
                     newRaster.save(ras)
-                    if spatialReference.name != 'Unknown':
+                    if spatialReference.name != "Unknown":
                         arcpy.DefineProjection_management(ras, spatialReference)
-                    ymin = ymin+hh*cellSize
+                    ymin = ymin + hh * cellSize
 
                     j -= 1
                     k += 1
-                xmin = xmin+ww*cellSize
+                xmin = xmin + ww * cellSize
                 i += 1
-                j = len(yList)-1
+                j = len(yList) - 1
                 ymin = extent.YMin
 
-            del(outArray) # release memory
-            tempRaster =  'tempRaster'
-            
-            arcpy.MosaicToNewRaster_management(itemList,tempWS, tempRaster, bathyRas, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
-            itemList.append(tempWS + '/' + tempRaster)
-            
+            del outArray  # release memory
+            tempRaster = "tempRaster"
+
+            arcpy.MosaicToNewRaster_management(
+                itemList,
+                tempWS,
+                tempRaster,
+                bathyRas,
+                "32_BIT_FLOAT",
+                "#",
+                "1",
+                "FIRST",
+                "FIRST",
+            )
+            itemList.append(tempWS + "/" + tempRaster)
+
             # Set nodata where nodata in the input DEM
-            newRaster = SetNull(IsNull(bathyRas),tempWS + '/' + tempRaster)
+            newRaster = SetNull(IsNull(bathyRas), tempWS + "/" + tempRaster)
             newRaster.save(outRas)
             self.deleteDataItems(itemList)
-            
 
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to generate openness.")
+        arcpy.AddMessage("took " + str(diff) + " to generate openness.")
         return
 
     # This function calculates TPI and uses TPI threshold to identify Bathymetric High features
-    def TPI_Tool(self,tempWS,bathyRas,tpiRas,outFeat,areaThreshold,areaUnit,tpiRadius,tpiSTDScale):
+    def TPI_Tool(
+        self,
+        tempWS,
+        bathyRas,
+        tpiRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        tpiRadius,
+        tpiSTDScale,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # tpiRas: output TPI grid
@@ -975,45 +1170,47 @@ class helpers(object):
         # areaUnit: input area unit of the areaThreshold
         # tpiRadius: input radius value of a circular window used to calculated TPI
         # tpiSTDScale: input TPI threshold used to identify Bathymetric High features
-        
+
         arcpy.AddMessage("running TPI tool ...")
 
-        tpiRasName = tpiRas[tpiRas.rfind("/")+1:]
+        tpiRasName = tpiRas[tpiRas.rfind("/") + 1 :]
         tpiRas1 = tempWS + "/" + tpiRasName
         # If the TPI raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate TPI with a defined tpiRadius only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(tpiRas1):
-            arcpy.Copy_management(tpiRas1,tpiRas)
-            arcpy.AddMessage(tpiRas+' exists and will be used')
-        elif tpiRadius == 0: # you have to set a radius greater than 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate TPI")
+            arcpy.Copy_management(tpiRas1, tpiRas)
+            arcpy.AddMessage(tpiRas + " exists and will be used")
+        elif tpiRadius == 0:  # you have to set a radius greater than 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate TPI"
+            )
             return
-        else: # calling the helper function to calculate TPI
-            arcpy.AddMessage("calculating TPI...")        
-            self.calculateTPI(bathyRas,tpiRadius,tpiRas)
+        else:  # calling the helper function to calculate TPI
+            arcpy.AddMessage("calculating TPI...")
+            self.calculateTPI(bathyRas, tpiRadius, tpiRas)
         # copy the TPI raster to a backup directory
-        arcpy.Copy_management(tpiRas,tpiRas1)
+        arcpy.Copy_management(tpiRas, tpiRas1)
 
         # obtain spatial mean and spatial standard deviation of the TPI grid
         tpiSTDResult = arcpy.GetRasterProperties_management(tpiRas, "STD")
-        stdText = tpiSTDResult.getOutput(0) 
-        if stdText.find(',') > 0:            
+        stdText = tpiSTDResult.getOutput(0)
+        if stdText.find(",") > 0:
             stdText = self.convertDecimalSeparator(stdText)
-            
+
         tpiSTD = float(stdText)
         tpiMEANResult = arcpy.GetRasterProperties_management(tpiRas, "MEAN")
         meanText = tpiMEANResult.getOutput(0)
-        if meanText.find(',') > 0:
+        if meanText.find(",") > 0:
             meanText = self.convertDecimalSeparator(stdText)
         tpiMean = float(meanText)
         # define the TPI threshold value for the subsequent mapping
-        tpiThreshold = tpiMean + float(tpiSTDScale)*tpiSTD        
-        arcpy.AddMessage("using tpi threshold "+str(tpiThreshold))
+        tpiThreshold = tpiMean + float(tpiSTDScale) * tpiSTD
+        arcpy.AddMessage("using tpi threshold " + str(tpiThreshold))
         tpiClassRas1 = tempWS + "/" + "tpiC"
         # select areas that satisfy the threshold condition
-        self.selectRaster(tpiRas,tpiClassRas1,tpiThreshold,">=")
-        
+        self.selectRaster(tpiRas, tpiClassRas1, tpiThreshold, ">=")
+
         # convert selected areas to polygons
         tpiPoly1 = tempWS + "/" + "tpiC_poly"
         arcpy.RasterToPolygon_conversion(tpiClassRas1, tpiPoly1, "NO_SIMPLIFY")
@@ -1021,25 +1218,38 @@ class helpers(object):
 
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(tpiPoly1,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(tpiPoly1, "AREA_GEODESIC", "", areaUnit1)
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThreshold)
         arcpy.AddMessage(str(areaThreshold))
-        
-        # further select areas based on the input area threshold       
+
+        # further select areas based on the input area threshold
         where_clause = '"AREA_GEO" >= ' + str(areaThreshold)
         arcpy.Select_analysis(tpiPoly1, outFeat, where_clause)
         arcpy.AddMessage("selection by area done")
-        
+
         arcpy.Delete_management(tpiPoly1)
-        arcpy.Delete_management(tpiClassRas1)  
+        arcpy.Delete_management(tpiClassRas1)
         self.deleteFields(outFeat)
         arcpy.AddMessage("TPI tool is done")
         return
 
     # This function calculates TPI and LMI and uses them to identify Bathymetric High features
-    def TPI_LMI_Tool(self,tempWS,bathyRas,tpiRas,outFeat,areaThreshold,areaUnit,tpiRadius,tpiSTDScaleLarge,tpiSTDScaleSmall,lmiWeightFile,lmiSTDScale):
+    def TPI_LMI_Tool(
+        self,
+        tempWS,
+        bathyRas,
+        tpiRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        tpiRadius,
+        tpiSTDScaleLarge,
+        tpiSTDScaleSmall,
+        lmiWeightFile,
+        lmiSTDScale,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # tpiRas: output TPI grid
@@ -1051,55 +1261,57 @@ class helpers(object):
         # tpiSTDScaleSmall: second input TPI threshold used to identify Bathymetric High features
         # lmiWeightFile: input weight kernel file for the calculaion of LMI
         # lmiSTDScale: input LMI threshold used to identify Bathymetric High features
-        
+
         arcpy.AddMessage("runing TPI_LMI tool ...")
-        
-        tpiRasName = tpiRas[tpiRas.rfind("/")+1:]
+
+        tpiRasName = tpiRas[tpiRas.rfind("/") + 1 :]
         tpiRas1 = tempWS + "/" + tpiRasName
-        
+
         # If the TPI raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate TPI with a defined tpiRadius only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(tpiRas1):
-            arcpy.Copy_management(tpiRas1,tpiRas)
-            arcpy.AddMessage(tpiRas+' exists and will be used')
-        elif tpiRadius == 0: # you have to set a radius greater than 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate TPI")
+            arcpy.Copy_management(tpiRas1, tpiRas)
+            arcpy.AddMessage(tpiRas + " exists and will be used")
+        elif tpiRadius == 0:  # you have to set a radius greater than 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate TPI"
+            )
             return
-        else: # calling the helper function to calculate TPI
-            arcpy.AddMessage("calculating TPI...")        
-            self.calculateTPI(bathyRas,tpiRadius,tpiRas)
+        else:  # calling the helper function to calculate TPI
+            arcpy.AddMessage("calculating TPI...")
+            self.calculateTPI(bathyRas, tpiRadius, tpiRas)
         # copy the TPI raster to a backup directory
-        arcpy.Copy_management(tpiRas,tpiRas1)
-        
+        arcpy.Copy_management(tpiRas, tpiRas1)
+
         interimDataList = []
 
         # obtain spatial mean and standard deviation of the TPI raster
-        # select first set of areas (features) with TPI >= tpiThresholdLarge       
+        # select first set of areas (features) with TPI >= tpiThresholdLarge
         # obtain spatial mean and spatial standard deviation of the TPI grid
         tpiSTDResult = arcpy.GetRasterProperties_management(tpiRas, "STD")
         stdText = tpiSTDResult.getOutput(0)
-        if stdText.find(',') > 0:
+        if stdText.find(",") > 0:
             stdText = self.convertDecimalSeparator(stdText)
         tpiSTD = float(stdText)
         tpiMEANResult = arcpy.GetRasterProperties_management(tpiRas, "MEAN")
         meanText = tpiMEANResult.getOutput(0)
-        if meanText.find(',') > 0:
+        if meanText.find(",") > 0:
             meanText = self.convertDecimalSeparator(stdText)
         tpiMean = float(meanText)
-        tpiThresholdLarge = tpiMean + float(tpiSTDScaleLarge)*tpiSTD        
+        tpiThresholdLarge = tpiMean + float(tpiSTDScaleLarge) * tpiSTD
         arcpy.AddMessage("using tpi threshold " + str(tpiThresholdLarge))
         tpiClassRas1 = tempWS + "/" + "tpiC"
         interimDataList.append(tpiClassRas1)
-        self.selectRaster(tpiRas,tpiClassRas1,tpiThresholdLarge,">=")
-        
-        # select second set of areas (features) with TPI >= tpiThresholdSmall           
-        tpiThresholdSmall = tpiMean + float(tpiSTDScaleSmall)*tpiSTD        
+        self.selectRaster(tpiRas, tpiClassRas1, tpiThresholdLarge, ">=")
+
+        # select second set of areas (features) with TPI >= tpiThresholdSmall
+        tpiThresholdSmall = tpiMean + float(tpiSTDScaleSmall) * tpiSTD
         arcpy.AddMessage("using tpi threshold " + str(tpiThresholdSmall))
         tpiClassRas2 = tempWS + "/" + "tpiC1"
         interimDataList.append(tpiClassRas2)
-        self.selectRaster(tpiRas,tpiClassRas2,tpiThresholdSmall,">=")
-        
+        self.selectRaster(tpiRas, tpiClassRas2, tpiThresholdSmall, ">=")
+
         # convert selected areas to polygons
         tpiPoly1 = tempWS + "/" + "tpiC_poly"
         interimDataList.append(tpiPoly1)
@@ -1110,51 +1322,60 @@ class helpers(object):
         arcpy.RasterToPolygon_conversion(tpiClassRas2, tpiPoly2, "NO_SIMPLIFY")
         arcpy.AddMessage("convert raster to polygon done")
 
- 
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(tpiPoly1,"AREA_GEODESIC","",areaUnit1)
-        arcpy.AddGeometryAttributes_management(tpiPoly2,"AREA_GEODESIC","",areaUnit1)
-        
+        arcpy.AddGeometryAttributes_management(tpiPoly1, "AREA_GEODESIC", "", areaUnit1)
+        arcpy.AddGeometryAttributes_management(tpiPoly2, "AREA_GEODESIC", "", areaUnit1)
+
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThreshold)
-        
-        # further select areas based on the input area threshold  
+
+        # further select areas based on the input area threshold
         tpiPoly1_selected = tempWS + "/" + "tpiC_poly_selected"
         interimDataList.append(tpiPoly1_selected)
         where_clause = '"AREA_GEO" >= ' + str(areaThreshold)
         arcpy.Select_analysis(tpiPoly1, tpiPoly1_selected, where_clause)
         arcpy.AddMessage("selection by area done")
-        
+
         # select based on location
         # only select the second set of features if they interset the first set
         tpiPoly2_selected = tempWS + "/" + "tpiC1_poly_selected"
         interimDataList.append(tpiPoly2_selected)
         layerName1 = "lyr1"
         arcpy.MakeFeatureLayer_management(tpiPoly2, layerName1)
-        arcpy.SelectLayerByLocation_management(layerName1, "intersect", tpiPoly1_selected)
+        arcpy.SelectLayerByLocation_management(
+            layerName1, "intersect", tpiPoly1_selected
+        )
         arcpy.CopyFeatures_management(layerName1, tpiPoly2_selected)
         arcpy.AddMessage("select by location done")
 
-        # further select areas based on the input area threshold  
+        # further select areas based on the input area threshold
         tpiPoly2_selected1 = tempWS + "/" + "tpiC1_poly_selected1"
         interimDataList.append(tpiPoly2_selected1)
         where_clause = '"AREA_GEO" >= ' + str(areaThreshold)
         arcpy.Select_analysis(tpiPoly2_selected, tpiPoly2_selected1, where_clause)
         arcpy.AddMessage("selection by area done")
-        
+
         # The follwing bits are key diferences from the TPI tool.
         # The general idea is to use TPI method to identify the first group of Bathymetric High features (codes above).
         # The areas of identified features are then removed (substracted) from the bathymetric grid.
         # We then apply LMI method on the remaining bathymetric grid and identify additional Bathymetric High features.
         count = int(arcpy.GetCount_management(tpiPoly2_selected1)[0])
-        if count > 50: # If more than 50 features in the second set, we will only work on the 50 largest features to save time
-            arcpy.AddMessage("there are " + str(count) + " features in " + tpiPoly2_selected1 + "; only 50 largest polygons will be processed for the next several steps")
+        if (
+            count > 50
+        ):  # If more than 50 features in the second set, we will only work on the 50 largest features to save time
+            arcpy.AddMessage(
+                "there are "
+                + str(count)
+                + " features in "
+                + tpiPoly2_selected1
+                + "; only 50 largest polygons will be processed for the next several steps"
+            )
             sortFeat = tempWS + "/" + "tpiC1_poly_selected1_sorted"
             interimDataList.append(sortFeat)
             sort_field = [["AREA_GEO", "DESCENDING"]]
-            arcpy.Sort_management(tpiPoly2_selected1,sortFeat,sort_field)
+            arcpy.Sort_management(tpiPoly2_selected1, sortFeat, sort_field)
             # select the largest 50 features and extractMask for these features
             tpiPoly2_selected1_1 = tempWS + "/" + "tpiC1_poly_selected1_1"
             interimDataList.append(tpiPoly2_selected1_1)
@@ -1168,19 +1389,20 @@ class helpers(object):
 
             # calling the helper function to extract rasters from the bathymetry data one by one based on the selected polygons above
             # for each extracted raster, select area with value >= threshold
-            extractedFeats = self.extractMask(tempWS,bathyRas,tpiPoly2_selected1_1)
-        else: # if less than 50 features in total
+            extractedFeats = self.extractMask(tempWS, bathyRas, tpiPoly2_selected1_1)
+        else:  # if less than 50 features in total
             # calling the helper function to extract rasters from the bathymetry data one by one based on the selected polygons above
             # for each extracted raster, select area with value >= threshold
-            extractedFeats = self.extractMask(tempWS,bathyRas,tpiPoly2_selected1)
-
+            extractedFeats = self.extractMask(tempWS, bathyRas, tpiPoly2_selected1)
 
         arcpy.AddMessage("extract done")
         # merge inFeats resulted from the extractMask function
         extractPoly = tempWS + "/" + "extracted_merged"
         interimDataList.append(extractPoly)
-        arcpy.Merge_management(extractedFeats,extractPoly)
-        arcpy.AddGeometryAttributes_management(extractPoly,"AREA_GEODESIC","",areaUnit1)
+        arcpy.Merge_management(extractedFeats, extractPoly)
+        arcpy.AddGeometryAttributes_management(
+            extractPoly, "AREA_GEODESIC", "", areaUnit1
+        )
         arcpy.AddMessage("merging done")
 
         # mosaic extracted rasters into a new raster
@@ -1193,46 +1415,45 @@ class helpers(object):
         extent = descData.Extent
         env.extent = extent
 
-
-        outExtract = ExtractByMask(bathyRas,extractPoly)
+        outExtract = ExtractByMask(bathyRas, extractPoly)
         outExtract.save(mosaicRas)
         arcpy.AddMessage("mosaic done")
 
         # substract the mosaic from the input bathymetric grid
         bathyRas1 = bathyRas + "_1"
         interimDataList.append(bathyRas1)
-        conDo = Con(IsNull(Raster(mosaicRas)),bathyRas)
+        conDo = Con(IsNull(Raster(mosaicRas)), bathyRas)
         conDo.save(bathyRas1)
         arcpy.AddMessage("substract done")
 
         # calling the helper function to calculate LMI from the new bathy
         lmiRas = tempWS + "/" + "LMI_1"
         interimDataList.append(lmiRas)
-        self.calculateLMI(bathyRas1,lmiWeightFile,lmiRas)
+        self.calculateLMI(bathyRas1, lmiWeightFile, lmiRas)
 
-        # select areas with LMI >= lmiThreshold            
+        # select areas with LMI >= lmiThreshold
         lmiSTDResult = arcpy.GetRasterProperties_management(lmiRas, "STD")
         lmiSTDText = lmiSTDResult.getOutput(0)
-        if lmiSTDText.find(',') > 0:
+        if lmiSTDText.find(",") > 0:
             lmiSTDText = self.convertDecimalSeparator(lmiSTDText)
         lmiSTD = float(lmiSTDText)
         lmiMEANResult = arcpy.GetRasterProperties_management(lmiRas, "MEAN")
         lmiMeanText = lmiMEANResult.getOutput(0)
-        if lmiMeanText.find(',') > 0:
+        if lmiMeanText.find(",") > 0:
             lmiMeanText = self.convertDecimalSeparator(lmiMeanText)
         lmiMean = float(lmiMeanText)
-        lmiThreshold = lmiMean + float(lmiSTDScale)*lmiSTD
+        lmiThreshold = lmiMean + float(lmiSTDScale) * lmiSTD
         arcpy.AddMessage("using LMI threshold " + str(lmiThreshold))
         lmiClassRas = tempWS + "/" + "LMI_1C"
         interimDataList.append(lmiClassRas)
-        self.selectRaster(lmiRas,lmiClassRas,lmiThreshold,">=")
+        self.selectRaster(lmiRas, lmiClassRas, lmiThreshold, ">=")
         arcpy.AddMessage("LMI selection done")
 
         # convert selected areas to polygons
         lmiPoly = tempWS + "/" + "LMI_1C_poly"
         interimDataList.append(lmiPoly)
         arcpy.RasterToPolygon_conversion(lmiClassRas, lmiPoly, "NO_SIMPLIFY")
-        arcpy.AddGeometryAttributes_management(lmiPoly,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(lmiPoly, "AREA_GEODESIC", "", areaUnit1)
         arcpy.AddMessage("convert raster to polygon done")
 
         # select based on location
@@ -1254,7 +1475,7 @@ class helpers(object):
         interimDataList.append(unionFeat)
         # note that using "NO_GAPS" option is able to fill holes. This would be good to fill small holes. But it also would potentially fill data gaps that should be kept.
         # We therefore decide to use "GAPS" option
-        arcpy.Union_analysis(inFeats,unionFeat,"ALL","#","GAPS") 
+        arcpy.Union_analysis(inFeats, unionFeat, "ALL", "#", "GAPS")
         arcpy.AddMessage("union done")
 
         # further select areas based on the input area threshold
@@ -1267,15 +1488,27 @@ class helpers(object):
         # use spatial join to join the attributes
         joinedFeat = tempWS + "/" + "unionFeat_joined"
         interimDataList.append(joinedFeat)
-        arcpy.SpatialJoin_analysis(unionFeat,extractPoly_selected,joinedFeat,"JOIN_ONE_TO_ONE","KEEP_ALL","#","INTERSECT")
+        arcpy.SpatialJoin_analysis(
+            unionFeat,
+            extractPoly_selected,
+            joinedFeat,
+            "JOIN_ONE_TO_ONE",
+            "KEEP_ALL",
+            "#",
+            "INTERSECT",
+        )
         arcpy.AddMessage("spatial join done")
 
         # dissolve the unioned features
         dissolvedFeat = tempWS + "/" + "unionFeat_joined_dissolved"
         interimDataList.append(dissolvedFeat)
         dissolveField = "gridcode_12"
-        arcpy.Dissolve_management(joinedFeat,dissolvedFeat,dissolveField,"#","SINGLE_PART")
-        arcpy.AddGeometryAttributes_management(dissolvedFeat,"AREA_GEODESIC","",areaUnit1)
+        arcpy.Dissolve_management(
+            joinedFeat, dissolvedFeat, dissolveField, "#", "SINGLE_PART"
+        )
+        arcpy.AddGeometryAttributes_management(
+            dissolvedFeat, "AREA_GEODESIC", "", areaUnit1
+        )
         arcpy.AddMessage("dissolve done")
         # The follwing codes are only needed for the second set that contains > 50 features
         if count > 50:
@@ -1285,44 +1518,51 @@ class helpers(object):
             interimDataList.append(tpiPoly1_selected1)
             newLayerName = "lyrNew"
             arcpy.MakeFeatureLayer_management(tpiPoly1_selected, newLayerName)
-            arcpy.SelectLayerByLocation_management(newLayerName, "intersect", dissolvedFeat, "#", "NEW_SELECTION", "INVERT")
+            arcpy.SelectLayerByLocation_management(
+                newLayerName, "intersect", dissolvedFeat, "#", "NEW_SELECTION", "INVERT"
+            )
             arcpy.CopyFeatures_management(newLayerName, tpiPoly1_selected1)
             arcpy.AddMessage("select by location done")
             # merge
             mergedFeat = tempWS + "/" + "unionFeat_joined_dissolved_merged"
             interimDataList.append(mergedFeat)
-            arcpy.Merge_management([tpiPoly1_selected1,dissolvedFeat],mergedFeat)
-            
+            arcpy.Merge_management([tpiPoly1_selected1, dissolvedFeat], mergedFeat)
+
             mergedFeat1 = tempWS + "/" + "unionFeat_joined_dissolved_merged1"
             interimDataList.append(mergedFeat1)
-            arcpy.MultipartToSinglepart_management(mergedFeat,mergedFeat1)
-            arcpy.AddGeometryAttributes_management(mergedFeat1,"AREA_GEODESIC","",areaUnit1)
-            
+            arcpy.MultipartToSinglepart_management(mergedFeat, mergedFeat1)
+            arcpy.AddGeometryAttributes_management(
+                mergedFeat1, "AREA_GEODESIC", "", areaUnit1
+            )
 
         # eliminate based on the area attribute
         eliminatedFeat = tempWS + "/" + "unionFeat_joined_dissolved_eliminated"
         interimDataList.append(eliminatedFeat)
         where_clause = '"AREA_GEO" < ' + str(areaThreshold)
         layerName3 = "lyr3"
-        if count > 50: # if more than 50 features, uses the merged features
+        if count > 50:  # if more than 50 features, uses the merged features
             arcpy.MakeFeatureLayer_management(mergedFeat1, layerName3)
-        else: # otherwise, uses the dissolved features
+        else:  # otherwise, uses the dissolved features
             arcpy.MakeFeatureLayer_management(dissolvedFeat, layerName3)
-        arcpy.SelectLayerByAttribute_management(layerName3, "NEW_SELECTION", where_clause)
-        arcpy.Eliminate_management(layerName3,eliminatedFeat,"AREA")
+        arcpy.SelectLayerByAttribute_management(
+            layerName3, "NEW_SELECTION", where_clause
+        )
+        arcpy.Eliminate_management(layerName3, eliminatedFeat, "AREA")
         arcpy.AddMessage("eliminate by area done")
 
         # delete features based on the area attribute
         where_clause = '"AREA_GEO" < ' + str(areaThreshold)
         layerName4 = "lyr4"
         arcpy.MakeFeatureLayer_management(eliminatedFeat, layerName4)
-        arcpy.SelectLayerByAttribute_management(layerName4, "NEW_SELECTION", where_clause)
+        arcpy.SelectLayerByAttribute_management(
+            layerName4, "NEW_SELECTION", where_clause
+        )
         if int(arcpy.GetCount_management(layerName4)[0]) > 0:
             arcpy.DeleteFeatures_management(layerName4)
         arcpy.AddMessage("delete features by area done")
 
         # copy the resulted features to the output featureclass
-        arcpy.Copy_management(eliminatedFeat,outFeat)
+        arcpy.Copy_management(eliminatedFeat, outFeat)
 
         # delete intermediate results
         if len(extractedFeats) > 0:
@@ -1335,7 +1575,19 @@ class helpers(object):
         return
 
     # This function calculates negative openness and uses it to identify Bathymetric High features
-    def opennessHigh(self,tempWS,bathyRas,noRas,outFeat,areaThreshold,areaUnit,noRadius,noSTDScaleLarge,noSTDScaleSmall,messages):
+    def opennessHigh(
+        self,
+        tempWS,
+        bathyRas,
+        noRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        noRadius,
+        noSTDScaleLarge,
+        noSTDScaleSmall,
+        messages,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # noRas: output negative openness grid
@@ -1348,44 +1600,48 @@ class helpers(object):
         # messages: to handle error messages
         arcpy.AddMessage("runing openness High tool ...")
 
-        noRasName = noRas[noRas.rfind("/")+1:]
-        
+        noRasName = noRas[noRas.rfind("/") + 1 :]
+
         noRas1 = tempWS + "/" + noRasName
         # If the negative openness raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate negative openness with a defined noRadius only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(noRas1):
-            arcpy.CopyRaster_management(noRas1,noRas)
-            arcpy.AddMessage(noRas+' exists and will be used')
-        elif noRadius == 0: # you have to set the radius > 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate openness")
+            arcpy.CopyRaster_management(noRas1, noRas)
+            arcpy.AddMessage(noRas + " exists and will be used")
+        elif noRadius == 0:  # you have to set the radius > 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate openness"
+            )
             return
-        else: # call the helper function to calculate negative openness
+        else:  # call the helper function to calculate negative openness
             arcpy.AddMessage("calculating Negative Openness...")
-            opennessParameter = 'negativeOpenness'
-            self.calculateOpenness(bathyRas, noRadius, opennessParameter, noRas, tempWS,messages)
+            opennessParameter = "negativeOpenness"
+            self.calculateOpenness(
+                bathyRas, noRadius, opennessParameter, noRas, tempWS, messages
+            )
         # copy the negative openness grid to a backup directory
-        arcpy.CopyRaster_management(noRas,noRas1)
-        
+        arcpy.CopyRaster_management(noRas, noRas1)
+
         interimDataList = []
 
         # The following codes are used to identify possible 'tops' (or 'peaks') or Bathymetry High features
         # The way doing that is to invert the bathymetry grid and then identify 'sink'
-        
+
         bathyRas1 = tempWS + "/" + "tempBathy"
         interimDataList.append(bathyRas1)
         # invert the input bathymetry grid
-        outM = Times(bathyRas,-1.0)
+        outM = Times(bathyRas, -1.0)
         outM.save(bathyRas1)
         # identify sinks
         fdRas = tempWS + "/" + "fdRas"
-        interimDataList.append(fdRas)  
+        interimDataList.append(fdRas)
         outFlowDirection = FlowDirection(bathyRas1)
         outFlowDirection.save(fdRas)
         arcpy.AddMessage("flow direction done")
 
         sinkRas = tempWS + "/" + "sinkRas"
-        interimDataList.append(sinkRas) 
+        interimDataList.append(sinkRas)
         outSink = Sink(fdRas)
         outSink.save(sinkRas)
         arcpy.AddMessage("sink done")
@@ -1395,32 +1651,31 @@ class helpers(object):
         interimDataList.append(sinksPoly)
         arcpy.RasterToPolygon_conversion(sinkRas, sinksPoly, "NO_SIMPLIFY")
         arcpy.AddMessage("convert sinks to polygon done")
-       
 
         # select first set of areas (features) with no <= noThresholdLarge
 
         noSTDResult = arcpy.GetRasterProperties_management(noRas, "STD")
         noSTDText = noSTDResult.getOutput(0)
-        if noSTDText.find(',') > 0:
+        if noSTDText.find(",") > 0:
             noSTDText = self.convertDecimalSeparator(noSTDText)
         noSTD = float(noSTDText)
         noMEANResult = arcpy.GetRasterProperties_management(noRas, "MEAN")
         noMeanText = noMEANResult.getOutput(0)
-        if noMeanText.find(',') > 0:
+        if noMeanText.find(",") > 0:
             noMeanText = self.convertDecimalSeparator(noMeanText)
         noMean = float(noMeanText)
-        noThresholdLarge = noMean - float(noSTDScaleLarge)*noSTD        
+        noThresholdLarge = noMean - float(noSTDScaleLarge) * noSTD
         arcpy.AddMessage("using no threshold " + str(noThresholdLarge))
         noClassRas1 = tempWS + "/" + "no_C"
-        self.selectRaster(noRas,noClassRas1,noThresholdLarge,"<=")
+        self.selectRaster(noRas, noClassRas1, noThresholdLarge, "<=")
         interimDataList.append(noClassRas1)
 
         # select second set of areas (features) with no <= noThresholdSmall
-           
-        noThresholdSmall = noMean - float(noSTDScaleSmall)*noSTD        
+
+        noThresholdSmall = noMean - float(noSTDScaleSmall) * noSTD
         arcpy.AddMessage("using no threshold " + str(noThresholdSmall))
         noClassRas2 = tempWS + "/" + "no_C1"
-        self.selectRaster(noRas,noClassRas2,noThresholdSmall,"<=")
+        self.selectRaster(noRas, noClassRas2, noThresholdSmall, "<=")
         interimDataList.append(noClassRas2)
 
         # convert selected areas to polygons
@@ -1433,11 +1688,10 @@ class helpers(object):
         arcpy.RasterToPolygon_conversion(noClassRas2, noPoly2, "NO_SIMPLIFY")
         arcpy.AddMessage("convert raster to polygon done")
 
-
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(noPoly1,"AREA_GEODESIC","",areaUnit1)
-        arcpy.AddGeometryAttributes_management(noPoly2,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(noPoly1, "AREA_GEODESIC", "", areaUnit1)
+        arcpy.AddGeometryAttributes_management(noPoly2, "AREA_GEODESIC", "", areaUnit1)
 
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
@@ -1472,12 +1726,19 @@ class helpers(object):
         arcpy.CopyFeatures_management(layerName2, noPoly2_selected1)
         arcpy.AddMessage("select by location done")
 
-
         # spatial join to join attributes
 
         joinedFeat = tempWS + "/" + "Feats_joined"
         interimDataList.append(joinedFeat)
-        arcpy.SpatialJoin_analysis(noPoly2_selected1,noPoly1_selected1,joinedFeat,"JOIN_ONE_TO_ONE","KEEP_ALL","#","INTERSECT")
+        arcpy.SpatialJoin_analysis(
+            noPoly2_selected1,
+            noPoly1_selected1,
+            joinedFeat,
+            "JOIN_ONE_TO_ONE",
+            "KEEP_ALL",
+            "#",
+            "INTERSECT",
+        )
         arcpy.AddMessage("spatial join done")
 
         # select by attribute
@@ -1485,7 +1746,7 @@ class helpers(object):
         # keep these features from the first set by using the select by location function
         joinedFeat_selected = tempWS + "/" + "Feats_joined_selected"
         interimDataList.append(joinedFeat_selected)
-        where_clause = '"Join_Count" >= 2' 
+        where_clause = '"Join_Count" >= 2'
         arcpy.Select_analysis(joinedFeat, joinedFeat_selected, where_clause)
         arcpy.AddMessage("select by attribute done")
         # select based on location
@@ -1493,7 +1754,9 @@ class helpers(object):
         interimDataList.append(noPoly1_selected2)
         layerName3 = "lyr3"
         arcpy.MakeFeatureLayer_management(noPoly1_selected1, layerName3)
-        arcpy.SelectLayerByLocation_management(layerName3, "intersect", joinedFeat_selected)
+        arcpy.SelectLayerByLocation_management(
+            layerName3, "intersect", joinedFeat_selected
+        )
         arcpy.CopyFeatures_management(layerName3, noPoly1_selected2)
         arcpy.AddMessage("select by location done")
         arcpy.AddMessage("first subset selection done")
@@ -1501,7 +1764,7 @@ class helpers(object):
         # If a feature from the second set intersects only one features from the first set, keep the feature from the second set
         joinedFeat_selected1 = tempWS + "/" + "Feats_joined_selected1"
         interimDataList.append(joinedFeat_selected1)
-        where_clause = '"Join_Count" < 2' 
+        where_clause = '"Join_Count" < 2'
         arcpy.Select_analysis(joinedFeat, joinedFeat_selected1, where_clause)
         arcpy.AddMessage("select by attribute done")
         arcpy.AddMessage("second subset selection done")
@@ -1509,13 +1772,11 @@ class helpers(object):
         # merge the two subsets of features to form the final set of Bathymetric High features
         mergedFeat = tempWS + "/" + "Feats_merged"
         interimDataList.append(mergedFeat)
-        arcpy.Merge_management([noPoly1_selected2,joinedFeat_selected1],mergedFeat)
+        arcpy.Merge_management([noPoly1_selected2, joinedFeat_selected1], mergedFeat)
         arcpy.AddMessage("merge done")
-        arcpy.Copy_management(mergedFeat,outFeat)
+        arcpy.Copy_management(mergedFeat, outFeat)
 
         # delete intermediate results
         self.deleteDataItems(interimDataList)
         self.deleteFields(outFeat)
         arcpy.AddMessage("Openness High tool is done")
-                    
-                    

--- a/Tools/BathymetricLow.pyt
+++ b/Tools/BathymetricLow.pyt
@@ -5,17 +5,16 @@
 #### Python version: 3+
 #### ArcGIS Pro: 2.6.4 and above
 
-import arcpy
-from arcpy import env
-from arcpy.sa import *
-import os
 import math
-import numpy as np
 import warnings
-from datetime import datetime 
+from datetime import datetime
+
+import arcpy
+import numpy as np
+from arcpy.sa import *
 
 
-class Toolbox(object):
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -24,10 +23,11 @@ class Toolbox(object):
 
         # List of tool classes associated with this toolbox
         # There are three tools in this toolset used to map Bathymetric High features.
-        self.tools = [TPIToolLow,Openness_Low_Tool,TPI_CI_Low_Tool]
+        self.tools = [TPIToolLow, Openness_Low_Tool, TPI_CI_Low_Tool]
+
 
 # TPIToolLow uses Topographic Position Index (TPI) technique to map Bathymetric Low features
-class TPIToolLow(object):
+class TPIToolLow:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "TPI Tool Bathymetric Low"
@@ -43,7 +43,8 @@ class TPIToolLow(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -51,7 +52,8 @@ class TPIToolLow(object):
             name="tpiRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -59,7 +61,8 @@ class TPIToolLow(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -67,24 +70,27 @@ class TPIToolLow(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")
-               
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="TPI Circle Radius (unit: cell)",
             name="tpiRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 3
-        
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="TPI STD Scale",
             name="tpiSTDScale",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 1.0
 
         # seventh parameter
@@ -93,9 +99,10 @@ class TPIToolLow(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param6.defaultEnvironmentName = "workspace"
-        
+
         parameters = [param0, param1, param2, param3, param4, param5, param6]
         return parameters
 
@@ -107,7 +114,6 @@ class TPIToolLow(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -118,7 +124,7 @@ class TPIToolLow(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         bathyRas = parameters[0].valueAsText
         tpiRas = parameters[1].valueAsText
         outFeat = parameters[2].valueAsText
@@ -136,7 +142,7 @@ class TPIToolLow(object):
         # In this case, the full path needs to be obtained from the map layer
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
@@ -145,60 +151,89 @@ class TPIToolLow(object):
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
         # check that the output TPI grid must be in a correct format
         if tpiRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = tpiRas[0:tpiRas.rfind("/")]
-        workspaceName2 = outFeat[0:outFeat.rfind("/")]
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = tpiRas[0 : tpiRas.rfind("/")]
+        workspaceName2 = outFeat[0 : outFeat.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        # waterproof some unusal errors       
+        areaUnit = areaThreshold.split(" ")[1]
+        # waterproof some unusal errors
         if tpiRas == outFeat:
-            messages.addErrorMessage("The output TPI raster and output Featureclass cannot have the same name in the same workspace!")
+            messages.addErrorMessage(
+                "The output TPI raster and output Featureclass cannot have the same name in the same workspace!"
+            )
             raise arcpy.ExecuteError
-            
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2):        
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
             raise arcpy.ExecuteError
-        
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-  
 
-        arcpy.env.workspace=workspaceName
+        arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to calculate TPI and generate output Bathymetric Low features
-        helper.TPI_Tool_Low(tempWS,bathyRas,tpiRas,outFeat,areaThresholdValue,areaUnit,tpiRadius,tpiSTDScale)
+        helper.TPI_Tool_Low(
+            tempWS,
+            bathyRas,
+            tpiRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            tpiRadius,
+            tpiSTDScale,
+        )
         return
-    
+
+
 # Openness_Low_Tool uses Openness technique to map Bathymetric Low features
-class Openness_Low_Tool(object):
+class Openness_Low_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Openness Tool Bathymetric Low"
-        self.description = "Cacluate Positive Openness and generate an output Featureclass"
+        self.description = (
+            "Cacluate Positive Openness and generate an output Featureclass"
+        )
         self.canRunInBackground = False
 
     def getParameterInfo(self):
@@ -210,7 +245,8 @@ class Openness_Low_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -218,7 +254,8 @@ class Openness_Low_Tool(object):
             name="poRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -226,7 +263,8 @@ class Openness_Low_Tool(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -234,24 +272,27 @@ class Openness_Low_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")       
-        
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="Openness Circle Radius (unit: cell)",
             name="poRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 3
-        
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="PO STD Scale Large",
             name="poSTDScaleLarge",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 2.0
 
         # seventh parameter
@@ -260,7 +301,8 @@ class Openness_Low_Tool(object):
             name="poSTDScaleSmall",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 1.0
 
         # eighth parameter
@@ -269,10 +311,10 @@ class Openness_Low_Tool(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param7.defaultEnvironmentName = "workspace"
 
-        
         parameters = [param0, param1, param2, param3, param4, param5, param6, param7]
         return parameters
 
@@ -284,7 +326,6 @@ class Openness_Low_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -305,69 +346,99 @@ class Openness_Low_Tool(object):
         poSTDScaleLarge = parameters[5].valueAsText
         poSTDScaleSmall = parameters[6].valueAsText
         tempWS = parameters[7].valueAsText
- 
+
         bathyRas = helper.convert_backslach_forwardslach(bathyRas)
         poRas = helper.convert_backslach_forwardslach(poRas)
         outFeat = helper.convert_backslach_forwardslach(outFeat)
         tempWS = helper.convert_backslach_forwardslach(tempWS)
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
-                        bathyRas = helper.convert_backslach_forwardslach(lyr.dataSource) 
+                        bathyRas = helper.convert_backslach_forwardslach(lyr.dataSource)
 
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
         # check that the output TPI grid must be in a correct format
         if poRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output PO raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output PO raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = poRas[0:poRas.rfind("/")]
-        workspaceName2 = outFeat[0:outFeat.rfind("/")]
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = poRas[0 : poRas.rfind("/")]
+        workspaceName2 = outFeat[0 : outFeat.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        # waterproof some unusal errors       
+        areaUnit = areaThreshold.split(" ")[1]
+        # waterproof some unusal errors
         if poRas == outFeat:
-            messages.addErrorMessage("The output Positive Openness raster and output Featureclass cannot have the same name in the same workspace!")
+            messages.addErrorMessage(
+                "The output Positive Openness raster and output Featureclass cannot have the same name in the same workspace!"
+            )
             raise arcpy.ExecuteError
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2):
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
             raise arcpy.ExecuteError
-        
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
-            raise arcpy.ExecuteError  
+            raise arcpy.ExecuteError
 
         arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to calculate openness and generate Bathymetric Low features
-        helper.opennessLow(tempWS,bathyRas,poRas,outFeat,areaThresholdValue,areaUnit,poRadius,poSTDScaleLarge,poSTDScaleSmall,messages)
-        return                              
+        helper.opennessLow(
+            tempWS,
+            bathyRas,
+            poRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            poRadius,
+            poSTDScaleLarge,
+            poSTDScaleSmall,
+            messages,
+        )
+        return
+
 
 # TPI_CI_Low_Tool use TPI and convergence index (CI) techniques to map Bathymetric Low features
-class TPI_CI_Low_Tool(object):
+class TPI_CI_Low_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "TPI CI Tool Bathymetric Low"
@@ -383,7 +454,8 @@ class TPI_CI_Low_Tool(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -391,7 +463,8 @@ class TPI_CI_Low_Tool(object):
             name="tpiRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -399,7 +472,8 @@ class TPI_CI_Low_Tool(object):
             name="ciRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -407,7 +481,8 @@ class TPI_CI_Low_Tool(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fifth parameter
         param4 = arcpy.Parameter(
@@ -415,24 +490,27 @@ class TPI_CI_Low_Tool(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")       
-        
+            direction="Input",
+        )
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="TPI Circle Radius (unit: cell)",
             name="tpiRadius",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 3
-        
+
         # seven parameter
         param6 = arcpy.Parameter(
             displayName="TPI STD Scale",
             name="tpiSTDScale",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 1.0
 
         # eight parameter
@@ -441,7 +519,8 @@ class TPI_CI_Low_Tool(object):
             name="ciSTDScale",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param7.value = 1.0
 
         # nineth parameter
@@ -450,7 +529,8 @@ class TPI_CI_Low_Tool(object):
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param8.defaultEnvironmentName = "workspace"
 
         # tenth parameter
@@ -459,10 +539,21 @@ class TPI_CI_Low_Tool(object):
             name="tempFolder",
             datatype="DEFolder",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
 
-        
-        parameters = [param0, param1, param2, param3, param4, param5, param6, param7, param8, param9]
+        parameters = [
+            param0,
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6,
+            param7,
+            param8,
+            param9,
+        ]
         return parameters
 
     def isLicensed(self):
@@ -473,7 +564,6 @@ class TPI_CI_Low_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -496,7 +586,7 @@ class TPI_CI_Low_Tool(object):
         ciSTDScale = parameters[7].valueAsText
         tempWS = parameters[8].valueAsText
         tempFolder = parameters[9].valueAsText
- 
+
         bathyRas = helper.convert_backslach_forwardslach(bathyRas)
         tpiRas = helper.convert_backslach_forwardslach(tpiRas)
         ciRas = helper.convert_backslach_forwardslach(ciRas)
@@ -505,7 +595,7 @@ class TPI_CI_Low_Tool(object):
         tempFolder = helper.convert_backslach_forwardslach(tempFolder)
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
@@ -514,120 +604,155 @@ class TPI_CI_Low_Tool(object):
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
         # check that the input bathymetry grid is in a projected coordinate system
         spatialReference = rasDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
         # check that the output TPI grid must be in a correct format
         if tpiRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output TPI raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
         # check that the output CI grid must be in a correct format
         if ciRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output CI raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output CI raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass must be in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace must be in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
-        workspaceName1 = tpiRas[0:tpiRas.rfind("/")]
-        workspaceName2 = ciRas[0:ciRas.rfind("/")]
-        workspaceName3 = outFeat[0:outFeat.rfind("/")]
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
+        workspaceName1 = tpiRas[0 : tpiRas.rfind("/")]
+        workspaceName2 = ciRas[0 : ciRas.rfind("/")]
+        workspaceName3 = outFeat[0 : outFeat.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
+        areaUnit = areaThreshold.split(" ")[1]
         # waterproof some unusual errors
         if (outFeat == tpiRas) or (outFeat == ciRas):
-            messages.addErrorMessage("The output CI and TPI rasters cannot have the same name as the output Featureclass in the same workspace!")
-            raise arcpy.ExecuteError            
-        if (tempWS == workspaceName) or (tempWS == workspaceName1) or (tempWS == workspaceName2) or (tempWS == workspaceName3):
-            messages.addErrorMessage("The temporary workspace must be different from the input/output workspace(s).")
+            messages.addErrorMessage(
+                "The output CI and TPI rasters cannot have the same name as the output Featureclass in the same workspace!"
+            )
             raise arcpy.ExecuteError
-        
+        if (
+            (tempWS == workspaceName)
+            or (tempWS == workspaceName1)
+            or (tempWS == workspaceName2)
+            or (tempWS == workspaceName3)
+        ):
+            messages.addErrorMessage(
+                "The temporary workspace must be different from the input/output workspace(s)."
+            )
+            raise arcpy.ExecuteError
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
-            raise arcpy.ExecuteError  
+            raise arcpy.ExecuteError
 
         arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to calculate TPI and CI, and map Bathymetric Low features
-        helper.TPI_CI_Low(tempWS,bathyRas,tpiRas,ciRas,outFeat,areaThresholdValue,areaUnit,tpiRadius,tpiSTDScale,ciSTDScale,tempFolder)
-        return                              
-                
+        helper.TPI_CI_Low(
+            tempWS,
+            bathyRas,
+            tpiRas,
+            ciRas,
+            outFeat,
+            areaThresholdValue,
+            areaUnit,
+            tpiRadius,
+            tpiSTDScale,
+            ciSTDScale,
+            tempFolder,
+        )
+        return
+
 
 # helper functions are defined below
-class helpers(object):
+class helpers:
 
     # This function converts comma decimal separator (e.g., European standard) to dot (e.g.,US, UK and Australian standard)
-    def convertDecimalSeparator(self,inText):
+    def convertDecimalSeparator(self, inText):
         # inText: input string representing a decimal number
-        textList = inText.split(',')
-        inText1 = textList[0] + '.' + textList[1]
+        textList = inText.split(",")
+        inText1 = textList[0] + "." + textList[1]
         return inText1
-    
-    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
-        # inText: input path
-        
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
 
-        inText = inText.replace('\\','/')
+    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
+    def convert_backslach_forwardslach(self, inText):
+        # inText: input path
+
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
+
+        inText = inText.replace("\\", "/")
         return inText
+
     # This function calculate TPI values from a bathymetry grid
-    def calculateTPI(self,bathy,radius,tpiRas):
+    def calculateTPI(self, bathy, radius, tpiRas):
         # bathy: input bathymetry grid
         # radius: the input radius value of a circle window
         # tpiRas: output TPI grid
-        
+
         time1 = datetime.now()
-        neighborhood = NbrCircle(radius,"CELL")
-        outFocal = FocalStatistics(bathy,neighborhood,"MEAN","DATA")
+        neighborhood = NbrCircle(radius, "CELL")
+        outFocal = FocalStatistics(bathy, neighborhood, "MEAN", "DATA")
         # TPI equals to the difference between the value of the centre cell and the mean value of its neighbourhood
         outMinus = Minus(bathy, outFocal)
         outMinus.save(tpiRas)
         arcpy.AddMessage("TPI is done")
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to generate TPI.")
+        arcpy.AddMessage("took " + str(diff) + " to generate TPI.")
         return
+
     # This function selects part of the raster based on a threshold value
-    def selectRaster(self,inRas,outRas,threshold,sign,value = 1):
+    def selectRaster(self, inRas, outRas, threshold, sign, value=1):
         # inRas: input raster
         # outRas: output raster
         # threshold: input threshold value used to select the inRas
         # sign: sign as part of the selection condition
         # value: the new raster value assigned to the part of the raster that satisfies the condition
-        
+
         if sign == ">=":
-            conDo = Con((Raster(inRas) >= threshold),value)
+            conDo = Con((Raster(inRas) >= threshold), value)
         elif sign == "<=":
-            conDo = Con((Raster(inRas) <= threshold),value)
+            conDo = Con((Raster(inRas) <= threshold), value)
         conDo.save(outRas)
 
     # This function deletes all intermediate data items
-    def deleteDataItems(self,inDataList):
+    def deleteDataItems(self, inDataList):
         # inDataList: a list of data items to be deleted
-        
+
         if len(inDataList) == 0:
             arcpy.AddMessage("no data item in the list")
-            
+
         else:
             for item in inDataList:
                 arcpy.AddMessage("Deleting " + item)
@@ -635,19 +760,19 @@ class helpers(object):
         return
 
     # This function deletes all unnecessary fields from the input featureclass
-    def deleteFields(self,inFeat):
+    def deleteFields(self, inFeat):
         # inFeat: input featureclass
-        fields = arcpy.ListFields(inFeat)        
+        fields = arcpy.ListFields(inFeat)
         fieldList = []
         for field in fields:
             if not field.required:
                 fieldList.append(field.name)
-        arcpy.DeleteField_management(inFeat,fieldList)
-        
+        arcpy.DeleteField_management(inFeat, fieldList)
+
     # This function calculates a converter value for the input area unit. The base unit is "SquareKilometers".
-    def areaUnitConverter(self,inAreaUnit):
+    def areaUnitConverter(self, inAreaUnit):
         # inAreaUnit: input Area Unit
-        
+
         if inAreaUnit == "Acres":
             converter = 0.00404686
         elif inAreaUnit == "Ares":
@@ -671,18 +796,21 @@ class helpers(object):
         elif inAreaUnit == "SquareMillimeters":
             converter = 0.000000000001
         elif inAreaUnit == "SquareYards":
-            converter = 0.00000083613       
+            converter = 0.00000083613
 
         return converter
+
     # This function calculates positive or negative openness value from the batymetry grid
-    def calculateOpenness(self,bathyRas,radius,opennessParameter,outRas,tempWS,messages):
+    def calculateOpenness(
+        self, bathyRas, radius, opennessParameter, outRas, tempWS, messages
+    ):
         # bathyRas: input bathymetry grid
         # radius: radius value of the analysis window
         # opennessParameter: determine whether to calculate positive or negative openness
         # outRas: output openness grid
         # tempWS: temporary workspace
         # messages: to handle error messages
-        
+
         ## most of the codes are taken from the "Openness" tool in the "ArcGeomorphometry Tools" python toolbox
         ## with the following modifications: 1) the analysis radius (window size) now accepts all positive integer values not limited to odd numbers only
         ## 2) the border areas are now processed properly instead of being left blank
@@ -691,7 +819,7 @@ class helpers(object):
         time1 = datetime.now()
         radius = int(radius)
         # the radius in the diagonal directions
-        radius1 = int(np.round(radius/np.sqrt(2)))
+        radius1 = int(np.round(radius / np.sqrt(2)))
 
         # Describe input raster
         descData = arcpy.Describe(bathyRas)
@@ -705,150 +833,203 @@ class helpers(object):
 
         spatialReference = descData.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage('    *** Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required. ***')
+            messages.addErrorMessage(
+                "    *** Coordinate system of input bathymetry grid is Geographic. A projected coordinate system is required. ***"
+            )
             raise arcpy.ExecuteError
-        pnt = arcpy.Point(xmin,ymin)
+        pnt = arcpy.Point(xmin, ymin)
 
         # Load DEM into numpy float32 array
         rasterDEMArray = arcpy.RasterToNumPyArray(bathyRas)
 
         # Check window size
         if radius > rasterDEMArray.shape[-1]:
-            messages.addErrorMessage('    *** Analysis window is too long. ***')
+            messages.addErrorMessage("    *** Analysis window is too long. ***")
             raise arcpy.ExecuteError
         #   calculate elevation angles within roughly circular search window (clockwise from N=0º)
         outShape = rasterDEMArray.shape
 
         outArray = np.zeros(outShape, dtype=np.float32)
         # the new array extends the loaded DEM array with a width of the radius from all four borders, so that the border areas of the loaded DEM can be processed properly
-        rasterDEMArray1 = np.arange((rasterDEMArray.shape[0]+2*radius)*(rasterDEMArray.shape[1]+2*radius)).reshape(rasterDEMArray.shape[0]+2*radius,rasterDEMArray.shape[1]+2*radius)
-        rasterDEMArray1 = np.zeros_like(rasterDEMArray1,dtype=float)
+        rasterDEMArray1 = np.arange(
+            (rasterDEMArray.shape[0] + 2 * radius)
+            * (rasterDEMArray.shape[1] + 2 * radius)
+        ).reshape(
+            rasterDEMArray.shape[0] + 2 * radius, rasterDEMArray.shape[1] + 2 * radius
+        )
+        rasterDEMArray1 = np.zeros_like(rasterDEMArray1, dtype=float)
         rasterDEMArray1[:] = np.nan
-        rasterDEMArray1[radius:rasterDEMArray.shape[0]+radius,radius:rasterDEMArray.shape[1]+radius]=rasterDEMArray
-        del(rasterDEMArray) # to release memory
+        rasterDEMArray1[
+            radius : rasterDEMArray.shape[0] + radius,
+            radius : rasterDEMArray.shape[1] + radius,
+        ] = rasterDEMArray
+        del rasterDEMArray  # to release memory
         #   set temporal arrays
         tempArray = np.zeros_like(outArray)
-        # arrayList holds the temporal arrays, so that we can calculate np.nanmean() 
+        # arrayList holds the temporal arrays, so that we can calculate np.nanmean()
         arrayList = []
-        shiftsList = [(x,y) for x in range(-radius,radius+1) for y in range(-radius,radius+1)]
+        shiftsList = [
+            (x, y)
+            for x in range(-radius, radius + 1)
+            for y in range(-radius, radius + 1)
+        ]
         #   calculate elevation angles within roughly circular search window (clockwise from N=0º)
         for direction in range(0, 360, 45):
             if direction == 0:
-                shiftsListD = filter (lambda arr: arr[0] < 0 and arr[1] == 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] < 0 and arr[1] == 0, shiftsList)
             elif direction == 45:
-                shiftsListD = filter (lambda arr: arr[1] < radius1+1 and arr[0] == -arr[1] and arr[1] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[1] < radius1 + 1
+                    and arr[0] == -arr[1]
+                    and arr[1] > 0,
+                    shiftsList,
+                )
             elif direction == 90:
-                shiftsListD = filter (lambda arr: arr[0] == 0 and arr[1] > 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] == 0 and arr[1] > 0, shiftsList)
             elif direction == 135:
-                shiftsListD = filter (lambda arr: arr[1] < radius1+1 and arr[0] == arr[1] and arr[0] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[1] < radius1 + 1
+                    and arr[0] == arr[1]
+                    and arr[0] > 0,
+                    shiftsList,
+                )
             elif direction == 180:
-                shiftsListD = filter (lambda arr: arr[0] > 0 and arr[1] == 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] > 0 and arr[1] == 0, shiftsList)
             elif direction == 225:
-                shiftsListD = filter (lambda arr: arr[0] < radius1+1 and arr[0] == -arr[1] and arr[0] > 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: arr[0] < radius1 + 1
+                    and arr[0] == -arr[1]
+                    and arr[0] > 0,
+                    shiftsList,
+                )
             elif direction == 270:
-                shiftsListD = filter (lambda arr: arr[0] == 0 and arr[1] < 0, shiftsList)
+                shiftsListD = filter(lambda arr: arr[0] == 0 and arr[1] < 0, shiftsList)
             elif direction == 315:
-                shiftsListD = filter (lambda arr: -arr[1] < radius1+1 and arr[0] == arr[1] and arr[0] < 0, shiftsList)
+                shiftsListD = filter(
+                    lambda arr: -arr[1] < radius1 + 1
+                    and arr[0] == arr[1]
+                    and arr[0] < 0,
+                    shiftsList,
+                )
 
-            if opennessParameter == 'positiveOpenness': # calculate positive openness
+            if opennessParameter == "positiveOpenness":  # calculate positive openness
                 tempArray.fill(-9999.9)
-                for dx,dy in shiftsListD:           
-                    xstop = -radius+dx or None
-                    ystop = -radius+dy or None
-                    angleArray = (rasterDEMArray1[radius+dx:xstop, radius+dy:ystop] - rasterDEMArray1[radius:-radius, radius:-radius]) / (math.hypot(dx, dy) * cellSize)
+                for dx, dy in shiftsListD:
+                    xstop = -radius + dx or None
+                    ystop = -radius + dy or None
+                    angleArray = (
+                        rasterDEMArray1[radius + dx : xstop, radius + dy : ystop]
+                        - rasterDEMArray1[radius:-radius, radius:-radius]
+                    ) / (math.hypot(dx, dy) * cellSize)
                     angleArray[np.isnan(angleArray)] = -999999.9
                     tempArray = np.maximum(tempArray, angleArray)
-                tempArray = np.where(tempArray < -9999,np.nan,tempArray)
+                tempArray = np.where(tempArray < -9999, np.nan, tempArray)
                 arrayList.append(90 - np.degrees(np.arctan(tempArray)))
-            elif opennessParameter == 'negativeOpenness': # calculate negative openness
+            elif opennessParameter == "negativeOpenness":  # calculate negative openness
                 tempArray.fill(9999.9)
-                for dx,dy in shiftsListD:
-                    xstop = -radius+dx or None
-                    ystop = -radius+dy or None
-                    angleArray = (rasterDEMArray1[radius+dx:xstop, radius+dy:ystop] - rasterDEMArray1[radius:-radius, radius:-radius]) / (math.hypot(dx, dy) * cellSize)
+                for dx, dy in shiftsListD:
+                    xstop = -radius + dx or None
+                    ystop = -radius + dy or None
+                    angleArray = (
+                        rasterDEMArray1[radius + dx : xstop, radius + dy : ystop]
+                        - rasterDEMArray1[radius:-radius, radius:-radius]
+                    ) / (math.hypot(dx, dy) * cellSize)
                     angleArray[np.isnan(angleArray)] = -999999.9
                     tempArray = np.minimum(tempArray, angleArray)
-                tempArray = np.where(tempArray < -9999,np.nan,tempArray)
+                tempArray = np.where(tempArray < -9999, np.nan, tempArray)
                 arrayList.append(90 + np.degrees(np.arctan(tempArray)))
-        del(rasterDEMArray1)
-        del(tempArray)
+        del rasterDEMArray1
+        del tempArray
         # np.stack() requires numpy version 1.10.0 or higher
         stacked_array = np.stack(arrayList)
         with warnings.catch_warnings():
             # ignore runtime warning
-            warnings.simplefilter("ignore",category=RuntimeWarning)
-            outArray = np.nanmean(stacked_array,axis=0)
-        
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            outArray = np.nanmean(stacked_array, axis=0)
+
         # Create new output calculated raster, set spatial coordinates and save
         # if the raster is more than 5000 cells in either X or Y directions, split the raster into blocks
         blocksize = 5000
         if (width <= blocksize) and (height <= blocksize):
-            newRaster = arcpy.NumPyArrayToRaster(outArray,pnt,cellSize,cellSize,-9999)
-            if spatialReference.name != 'Unknown':
+            newRaster = arcpy.NumPyArrayToRaster(
+                outArray, pnt, cellSize, cellSize, -9999
+            )
+            if spatialReference.name != "Unknown":
                 arcpy.DefineProjection_management(newRaster, spatialReference)
             # Set nodata where nodata in the input DEM
-            newRaster = SetNull(IsNull(bathyRas),newRaster)
+            newRaster = SetNull(IsNull(bathyRas), newRaster)
             newRaster.save(outRas)
-            del(outArray)
-        else:            
+            del outArray
+        else:
             itemList = []
             xList = []
             yList = []
-            for x in range(0,width,blocksize):
+            for x in range(0, width, blocksize):
                 xList.append(x)
-            for y in range(0,height,blocksize):
+            for y in range(0, height, blocksize):
                 yList.append(y)
             xList.append(width)
             yList.append(height)
 
             i = 0
-            j = len(yList)-1
+            j = len(yList) - 1
             k = 0
-            while i < len(xList)-1:
+            while i < len(xList) - 1:
                 while j > 0:
-                    arr = outArray[yList[j-1]:yList[j],xList[i]:xList[i+1]]
+                    arr = outArray[yList[j - 1] : yList[j], xList[i] : xList[i + 1]]
                     hh = arr.shape[0]
                     ww = arr.shape[1]
-                    pnt = arcpy.Point(xmin,ymin)
-                    newRaster = arcpy.NumPyArrayToRaster(arr,pnt,cellSize,cellSize,-9999)
-                    ras = tempWS + '/' + 'tempRas' + str(k)
+                    pnt = arcpy.Point(xmin, ymin)
+                    newRaster = arcpy.NumPyArrayToRaster(
+                        arr, pnt, cellSize, cellSize, -9999
+                    )
+                    ras = tempWS + "/" + "tempRas" + str(k)
                     itemList.append(ras)
                     newRaster.save(ras)
-                    if spatialReference.name != 'Unknown':
+                    if spatialReference.name != "Unknown":
                         arcpy.DefineProjection_management(ras, spatialReference)
-                    ymin = ymin+hh*cellSize
+                    ymin = ymin + hh * cellSize
 
                     j -= 1
                     k += 1
-                xmin = xmin+ww*cellSize
+                xmin = xmin + ww * cellSize
                 i += 1
-                j = len(yList)-1
+                j = len(yList) - 1
                 ymin = extent.YMin
 
-            del(outArray)
-            tempRaster =  'tempRaster'
-            
-            arcpy.MosaicToNewRaster_management(itemList,tempWS, tempRaster, bathyRas, "32_BIT_FLOAT", "#", "1", "FIRST","FIRST")
-            itemList.append(tempWS + '/' + tempRaster)
-            
+            del outArray
+            tempRaster = "tempRaster"
+
+            arcpy.MosaicToNewRaster_management(
+                itemList,
+                tempWS,
+                tempRaster,
+                bathyRas,
+                "32_BIT_FLOAT",
+                "#",
+                "1",
+                "FIRST",
+                "FIRST",
+            )
+            itemList.append(tempWS + "/" + tempRaster)
+
             # Set nodata where nodata in the input DEM
-            newRaster = SetNull(IsNull(bathyRas),tempWS + '/' + tempRaster)
+            newRaster = SetNull(IsNull(bathyRas), tempWS + "/" + tempRaster)
             newRaster.save(outRas)
             self.deleteDataItems(itemList)
-            
 
         time2 = datetime.now()
         diff = time2 - time1
-        arcpy.AddMessage("took "+str(diff)+" to generate openness.")
+        arcpy.AddMessage("took " + str(diff) + " to generate openness.")
         return
 
     # This function calculates convergence index (CI) from an Aspect grid
-    def calculateCI(self,aspectRas,ciRas,tempFolder):
+    def calculateCI(self, aspectRas, ciRas, tempFolder):
         # aspectRas: input Aspect grid
         # ciRas: output CI grid
         # tempFolder: temporary folder to store temporary files
-        
-        directionList = ["N","NE","E","SE","S","SW","W","NW"]
+
+        directionList = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
         temRasList = []
         fileName = tempFolder + "/weight.txt"
         text1 = "0 0 0"
@@ -858,21 +1039,21 @@ class helpers(object):
         # for each direction, construct a kernel file and calculate focal statistic of the Aspect grid
         for direction in directionList:
             fileName = tempFolder + "/weight_" + direction + ".txt"
-            f = open(fileName,"w")
+            f = open(fileName, "w")
             f.write("3 3\n")
-            if direction == "N":            
+            if direction == "N":
                 f.write(text3 + "\n")
                 f.write(text1 + "\n")
                 f.write(text1 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
-                focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA") 
+                focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 180
             elif direction == "NE":
                 f.write(text4 + "\n")
                 f.write(text1 + "\n")
                 f.write(text1 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 225
@@ -880,7 +1061,7 @@ class helpers(object):
                 f.write(text1 + "\n")
                 f.write(text4 + "\n")
                 f.write(text1 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 270
@@ -888,7 +1069,7 @@ class helpers(object):
                 f.write(text1 + "\n")
                 f.write(text1 + "\n")
                 f.write(text4 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 315
@@ -896,7 +1077,7 @@ class helpers(object):
                 f.write(text1 + "\n")
                 f.write(text1 + "\n")
                 f.write(text3 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 0
@@ -904,7 +1085,7 @@ class helpers(object):
                 f.write(text1 + "\n")
                 f.write(text1 + "\n")
                 f.write(text2 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 45
@@ -912,36 +1093,46 @@ class helpers(object):
                 f.write(text1 + "\n")
                 f.write(text2 + "\n")
                 f.write(text1 + "\n")
-                f.close()            
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 90
             elif direction == "NW":
                 f.write(text2 + "\n")
                 f.write(text1 + "\n")
-                f.write(text1 + "\n")            
-                f.close()            
+                f.write(text1 + "\n")
+                f.close()
                 NbrWeight1 = NbrWeight(fileName)
                 focal1 = FocalStatistics(aspectRas, NbrWeight1, "SUM", "DATA")
                 angle1 = 135
-            arcpy.AddMessage("focal statistics done " + direction)   
-            abs1 = Abs(focal1-angle1)
-            s1 = Con(abs1 > 180, Minus(360,abs1), abs1)
+            arcpy.AddMessage("focal statistics done " + direction)
+            abs1 = Abs(focal1 - angle1)
+            s1 = Con(abs1 > 180, Minus(360, abs1), abs1)
             temRas = "temRas_" + direction
             s1.save(temRas)
             temRasList.append(temRas)
         # combine the eight directional grids using cell statistic
-        outCS = CellStatistics(temRasList,"MEAN","DATA")
-        ci = Minus(outCS,90)    
+        outCS = CellStatistics(temRasList, "MEAN", "DATA")
+        ci = Minus(outCS, 90)
         ci.save(ciRas)
         arcpy.AddMessage("CI is done")
         # delete intermediate data
         self.deleteDataItems(temRasList)
-        arcpy.AddMessage("delete done")                      
-        return                      
+        arcpy.AddMessage("delete done")
+        return
 
-    # This function calculates TPI and uses TPI threshold to identify Bathymetric High features        
-    def TPI_Tool_Low(self,tempWS,bathyRas,tpiRas,outFeat,areaThreshold,areaUnit,tpiRadius,tpiSTDScale):
+    # This function calculates TPI and uses TPI threshold to identify Bathymetric High features
+    def TPI_Tool_Low(
+        self,
+        tempWS,
+        bathyRas,
+        tpiRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        tpiRadius,
+        tpiSTDScale,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # tpiRas: output TPI grid
@@ -949,45 +1140,47 @@ class helpers(object):
         # areaThreshold: input area threshold value
         # areaUnit: input area unit of the areaThreshold
         # tpiRadius: input radius value of a circular window used to calculated TPI
-        # tpiSTDScale: input TPI threshold used to identify Bathymetric Low features        
+        # tpiSTDScale: input TPI threshold used to identify Bathymetric Low features
 
         arcpy.AddMessage("running TPI tool ...")
 
-        tpiRasName = tpiRas[tpiRas.rfind("/")+1:]
+        tpiRasName = tpiRas[tpiRas.rfind("/") + 1 :]
         tpiRas1 = tempWS + "/" + tpiRasName
         # If the TPI raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate TPI with a defined tpiRadius only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(tpiRas1):
-            arcpy.Copy_management(tpiRas1,tpiRas)
-            arcpy.AddMessage(tpiRas+' exists and will be used')
-        elif tpiRadius == 0: # you have to set a radius greater than 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate TPI")
+            arcpy.Copy_management(tpiRas1, tpiRas)
+            arcpy.AddMessage(tpiRas + " exists and will be used")
+        elif tpiRadius == 0:  # you have to set a radius greater than 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate TPI"
+            )
             return
-        else: # calling the helper function to calculate TPI
-            arcpy.AddMessage("calculating TPI...")        
-            self.calculateTPI(bathyRas,tpiRadius,tpiRas)
+        else:  # calling the helper function to calculate TPI
+            arcpy.AddMessage("calculating TPI...")
+            self.calculateTPI(bathyRas, tpiRadius, tpiRas)
         # copy the TPI raster to a backup directory
-        arcpy.Copy_management(tpiRas,tpiRas1)
+        arcpy.Copy_management(tpiRas, tpiRas1)
 
         # obtain spatial mean and spatial standard deviation of the TPI grid
         tpiSTDResult = arcpy.GetRasterProperties_management(tpiRas, "STD")
         stdText = tpiSTDResult.getOutput(0)
-        if stdText.find(',') > 0:
-            stdText = self.convertDecimalSeparator(stdText)        
+        if stdText.find(",") > 0:
+            stdText = self.convertDecimalSeparator(stdText)
         tpiSTD = float(stdText)
         tpiMEANResult = arcpy.GetRasterProperties_management(tpiRas, "MEAN")
         meanText = tpiMEANResult.getOutput(0)
-        if meanText.find(',') > 0:
-            meanText = self.convertDecimalSeparator(meanText)        
+        if meanText.find(",") > 0:
+            meanText = self.convertDecimalSeparator(meanText)
         tpiMean = float(meanText)
         # define the TPI threshold value for the subsequent mapping
-        tpiThreshold = tpiMean - float(tpiSTDScale)*tpiSTD        
-        arcpy.AddMessage("using tpi threshold "+str(tpiThreshold))
+        tpiThreshold = tpiMean - float(tpiSTDScale) * tpiSTD
+        arcpy.AddMessage("using tpi threshold " + str(tpiThreshold))
         tpiClassRas1 = tempWS + "/" + "tpiC"
         # select areas that satisfy the threshold condition
-        self.selectRaster(tpiRas,tpiClassRas1,tpiThreshold,"<=")
-        
+        self.selectRaster(tpiRas, tpiClassRas1, tpiThreshold, "<=")
+
         # convert selected areas to polygons
         tpiPoly1 = tempWS + "/" + "tpiC_poly"
         arcpy.RasterToPolygon_conversion(tpiClassRas1, tpiPoly1, "NO_SIMPLIFY")
@@ -995,26 +1188,38 @@ class helpers(object):
 
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(tpiPoly1,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(tpiPoly1, "AREA_GEODESIC", "", areaUnit1)
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThreshold)
         arcpy.AddMessage(str(areaThreshold))
-        
-        # further select areas based on the input area threshold      
+
+        # further select areas based on the input area threshold
         where_clause = '"AREA_GEO" >= ' + str(areaThreshold)
         arcpy.Select_analysis(tpiPoly1, outFeat, where_clause)
         arcpy.AddMessage("selection by area done")
-        
+
         arcpy.Delete_management(tpiPoly1)
-        arcpy.Delete_management(tpiClassRas1)  
-        self.deleteFields(outFeat)  
-        
+        arcpy.Delete_management(tpiClassRas1)
+        self.deleteFields(outFeat)
+
         arcpy.AddMessage("TPI tool is done")
         return
 
     # This function calculates positive openness and uses it to identify Bathymetric Low features
-    def opennessLow(self,tempWS,bathyRas,poRas,outFeat,areaThreshold,areaUnit,poRadius,poSTDScaleLarge,poSTDScaleSmall,messages):
+    def opennessLow(
+        self,
+        tempWS,
+        bathyRas,
+        poRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        poRadius,
+        poSTDScaleLarge,
+        poSTDScaleSmall,
+        messages,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # poRas: output positive openness grid
@@ -1027,38 +1232,42 @@ class helpers(object):
         # messages: to handle error messages
         arcpy.AddMessage("runing openness Low tool ...")
 
-        poRasName = poRas[poRas.rfind("/")+1:]
-        
+        poRasName = poRas[poRas.rfind("/") + 1 :]
+
         poRas1 = tempWS + "/" + poRasName
         # If the positive openness raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate positive openness with a defined noRadius only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(poRas1):
-            arcpy.CopyRaster_management(poRas1,poRas)
-            arcpy.AddMessage(poRas+' exists and will be used')
-        elif poRadius == 0: # you have to set the radius > 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate openness")
+            arcpy.CopyRaster_management(poRas1, poRas)
+            arcpy.AddMessage(poRas + " exists and will be used")
+        elif poRadius == 0:  # you have to set the radius > 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate openness"
+            )
             return
-        else: # call the helper function to calculate positive openness
+        else:  # call the helper function to calculate positive openness
             arcpy.AddMessage("calculating Positive Openness...")
-            opennessParameter = 'positiveOpenness'
-            self.calculateOpenness(bathyRas, poRadius, opennessParameter, poRas, tempWS, messages)
-        arcpy.CopyRaster_management(poRas,poRas1)
-        
+            opennessParameter = "positiveOpenness"
+            self.calculateOpenness(
+                bathyRas, poRadius, opennessParameter, poRas, tempWS, messages
+            )
+        arcpy.CopyRaster_management(poRas, poRas1)
+
         interimDataList = []
 
         # The following codes are used to identify possible 'bottoms' (or 'pits') or Bathymetry Low features
-        # The way doing that is to iidentify sinks       
+        # The way doing that is to iidentify sinks
 
         # identify sinks
         fdRas = tempWS + "/" + "fdRas"
-        interimDataList.append(fdRas)  
+        interimDataList.append(fdRas)
         outFlowDirection = FlowDirection(bathyRas)
         outFlowDirection.save(fdRas)
         arcpy.AddMessage("flow direction done")
 
         sinkRas = tempWS + "/" + "sinkRas"
-        interimDataList.append(sinkRas) 
+        interimDataList.append(sinkRas)
         outSink = Sink(fdRas)
         outSink.save(sinkRas)
         arcpy.AddMessage("sink done")
@@ -1068,30 +1277,29 @@ class helpers(object):
         interimDataList.append(sinksPoly)
         arcpy.RasterToPolygon_conversion(sinkRas, sinksPoly, "NO_SIMPLIFY")
         arcpy.AddMessage("convert sinks to polygon done")
-       
 
         # select first set of areas (features) areas with po <= poThresholdLarge
         poSTDResult = arcpy.GetRasterProperties_management(poRas, "STD")
         stdText = poSTDResult.getOutput(0)
-        if stdText.find(',') > 0:
-            stdText = self.convertDecimalSeparator(stdText)        
+        if stdText.find(",") > 0:
+            stdText = self.convertDecimalSeparator(stdText)
         poSTD = float(stdText)
         poMEANResult = arcpy.GetRasterProperties_management(poRas, "MEAN")
         meanText = poMEANResult.getOutput(0)
-        if meanText.find(',') > 0:
+        if meanText.find(",") > 0:
             meanText = self.convertDecimalSeparator(meanText)
         poMean = float(meanText)
-        poThresholdLarge = poMean - float(poSTDScaleLarge)*poSTD        
+        poThresholdLarge = poMean - float(poSTDScaleLarge) * poSTD
         arcpy.AddMessage("using po threshold " + str(poThresholdLarge))
         poClassRas1 = tempWS + "/" + "po_C"
-        self.selectRaster(poRas,poClassRas1,poThresholdLarge,"<=")
+        self.selectRaster(poRas, poClassRas1, poThresholdLarge, "<=")
         interimDataList.append(poClassRas1)
 
-        # select second set of areas (features) areas with po <= poThresholdSmall           
-        poThresholdSmall = poMean - float(poSTDScaleSmall)*poSTD        
+        # select second set of areas (features) areas with po <= poThresholdSmall
+        poThresholdSmall = poMean - float(poSTDScaleSmall) * poSTD
         arcpy.AddMessage("using po threshold " + str(poThresholdSmall))
         poClassRas2 = tempWS + "/" + "po_C1"
-        self.selectRaster(poRas,poClassRas2,poThresholdSmall,"<=")
+        self.selectRaster(poRas, poClassRas2, poThresholdSmall, "<=")
         interimDataList.append(poClassRas2)
 
         # convert selected areas to polygons
@@ -1104,11 +1312,10 @@ class helpers(object):
         arcpy.RasterToPolygon_conversion(poClassRas2, poPoly2, "NO_SIMPLIFY", "VALUE")
         arcpy.AddMessage("convert raster to polygon done")
 
-
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(poPoly1,"AREA_GEODESIC","",areaUnit1)
-        arcpy.AddGeometryAttributes_management(poPoly2,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(poPoly1, "AREA_GEODESIC", "", areaUnit1)
+        arcpy.AddGeometryAttributes_management(poPoly2, "AREA_GEODESIC", "", areaUnit1)
 
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
@@ -1143,11 +1350,18 @@ class helpers(object):
         arcpy.CopyFeatures_management(layerName2, poPoly2_selected1)
         arcpy.AddMessage("select by location done")
 
-
         # spatial join to join attributes
         joinedFeat = tempWS + "/" + "Feats_joined"
         interimDataList.append(joinedFeat)
-        arcpy.SpatialJoin_analysis(poPoly2_selected1,poPoly1_selected1,joinedFeat,"JOIN_ONE_TO_ONE","KEEP_ALL","#","INTERSECT")
+        arcpy.SpatialJoin_analysis(
+            poPoly2_selected1,
+            poPoly1_selected1,
+            joinedFeat,
+            "JOIN_ONE_TO_ONE",
+            "KEEP_ALL",
+            "#",
+            "INTERSECT",
+        )
         arcpy.AddMessage("spatial join done")
 
         # select by attribute
@@ -1155,20 +1369,22 @@ class helpers(object):
         # keep these features from the first set by using the select by location function
         joinedFeat_selected = tempWS + "/" + "Feats_joined_selected"
         interimDataList.append(joinedFeat_selected)
-        where_clause = '"Join_Count" >= 2' 
+        where_clause = '"Join_Count" >= 2'
         arcpy.Select_analysis(joinedFeat, joinedFeat_selected, where_clause)
         # select based on location
         poPoly1_selected2 = tempWS + "/" + "poC_poly_selected2"
         interimDataList.append(poPoly1_selected2)
         layerName3 = "lyr3"
         arcpy.MakeFeatureLayer_management(poPoly1_selected1, layerName3)
-        arcpy.SelectLayerByLocation_management(layerName3, "intersect", joinedFeat_selected)
+        arcpy.SelectLayerByLocation_management(
+            layerName3, "intersect", joinedFeat_selected
+        )
         arcpy.CopyFeatures_management(layerName3, poPoly1_selected2)
         arcpy.AddMessage("select by location done")
         # If a feature from the second set intersects only one features from the first set, keep the feature from the second set
         joinedFeat_selected1 = tempWS + "/" + "Feats_joined_selected1"
         interimDataList.append(joinedFeat_selected1)
-        where_clause = '"Join_Count" < 2' 
+        where_clause = '"Join_Count" < 2'
         arcpy.Select_analysis(joinedFeat, joinedFeat_selected1, where_clause)
         arcpy.AddMessage("select by attribute done")
 
@@ -1176,18 +1392,31 @@ class helpers(object):
 
         mergedFeat = tempWS + "/" + "Feats_merged"
         interimDataList.append(mergedFeat)
-        arcpy.Merge_management([poPoly1_selected2,joinedFeat_selected1],mergedFeat)
+        arcpy.Merge_management([poPoly1_selected2, joinedFeat_selected1], mergedFeat)
         arcpy.AddMessage("merge done")
-        arcpy.Copy_management(mergedFeat,outFeat)
+        arcpy.Copy_management(mergedFeat, outFeat)
 
         # delete intermediate results
-        self.deleteDataItems(interimDataList)  
+        self.deleteDataItems(interimDataList)
         self.deleteFields(outFeat)
-        
+
         arcpy.AddMessage("Openness Low tool is done")
 
     # This function calculates TPI and CI, and then use them to map the Bathymetric Low features
-    def TPI_CI_Low(self,tempWS,bathyRas,tpiRas,ciRas,outFeat,areaThreshold,areaUnit,tpiRadius,tpiSTDScale,ciSTDScale,tempFolder):
+    def TPI_CI_Low(
+        self,
+        tempWS,
+        bathyRas,
+        tpiRas,
+        ciRas,
+        outFeat,
+        areaThreshold,
+        areaUnit,
+        tpiRadius,
+        tpiSTDScale,
+        ciSTDScale,
+        tempFolder,
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # tpiRas: output TPI grid
@@ -1198,24 +1427,23 @@ class helpers(object):
         # tpiRadius: input radius value of a circular window used to calculated TPI
         # tpiSTDScale: input TPI threshold used to identify Bathymetric Low features
         # ciSTDScale: input CI threshold used to identify Bathymetric Low features
-        # tempFolder: temporary folder to store temporary files        
+        # tempFolder: temporary folder to store temporary files
 
         arcpy.AddMessage("runing TPI CI Low tool ...")
 
         interimDataList = []
         descData = arcpy.Describe(bathyRas)
-        cellsize = descData.meanCellHeight            
+        cellsize = descData.meanCellHeight
 
-
-        # calculate the convergence index (CI)            
-        ciRasName = ciRas[ciRas.rfind("/")+1:]
+        # calculate the convergence index (CI)
+        ciRasName = ciRas[ciRas.rfind("/") + 1 :]
         ciRas1 = tempWS + "/" + ciRasName
         # If the CI raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate CI only once,
         # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(ciRas1):
-            arcpy.CopyRaster_management(ciRas1,ciRas)
-            arcpy.AddMessage(ciRas+' exists and will be used')
+            arcpy.CopyRaster_management(ciRas1, ciRas)
+            arcpy.AddMessage(ciRas + " exists and will be used")
         else:
             arcpy.AddMessage("calculating CI...")
             # fill the sinks on the bathymetry data
@@ -1233,72 +1461,84 @@ class helpers(object):
             arcpy.AddMessage("Aspect Raster generated")
 
             # call the helper function to calculate CI
-            self.calculateCI(aspectRas,ciRas,tempFolder)
+            self.calculateCI(aspectRas, ciRas, tempFolder)
         # copy the CI raster to a backup directory
-        arcpy.CopyRaster_management(ciRas,ciRas1)
-        
+        arcpy.CopyRaster_management(ciRas, ciRas1)
+
         # calculate the TPI
-        tpiRasName = tpiRas[tpiRas.rfind("/")+1:]
+        tpiRasName = tpiRas[tpiRas.rfind("/") + 1 :]
         tpiRas1 = tempWS + "/" + tpiRasName
         # If the TPI raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate TPI with a defined tpiRadius only once,
-        # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid. 
+        # as the calculation may takes a long time depending on the radius value and the size of the bathymetric grid.
         if arcpy.Exists(tpiRas1):
-            arcpy.CopyRaster_management(tpiRas1,tpiRas)
-            arcpy.AddMessage(tpiRas+' exists and will be used')
-        elif tpiRadius == 0: # you have to set radius > 0
-            arcpy.AddMessage("You must provide a radius greater than 0 to calculate tpi")
+            arcpy.CopyRaster_management(tpiRas1, tpiRas)
+            arcpy.AddMessage(tpiRas + " exists and will be used")
+        elif tpiRadius == 0:  # you have to set radius > 0
+            arcpy.AddMessage(
+                "You must provide a radius greater than 0 to calculate tpi"
+            )
             return
         else:
-            arcpy.AddMessage("calculating TPI...")                
-            self.calculateTPI(bathyRas1,tpiRadius,tpiRas)
+            arcpy.AddMessage("calculating TPI...")
+            self.calculateTPI(bathyRas1, tpiRadius, tpiRas)
         # copy the TPI raster to a backup directory
-        arcpy.CopyRaster_management(tpiRas,tpiRas1)
-        
+        arcpy.CopyRaster_management(tpiRas, tpiRas1)
+
         # obtain spatial mean and standard deviation of the CI grid
         # select CI based on the threshold
         ciSTDResult = arcpy.GetRasterProperties_management(ciRas, "STD")
         cistdText = ciSTDResult.getOutput(0)
-        if cistdText.find(',') > 0:
-            cistdText = self.convertDecimalSeparator(cistdText)        
+        if cistdText.find(",") > 0:
+            cistdText = self.convertDecimalSeparator(cistdText)
         ciSTD = float(cistdText)
         ciMEANResult = arcpy.GetRasterProperties_management(ciRas, "MEAN")
         cimeanText = ciMEANResult.getOutput(0)
-        if cimeanText.find(',') > 0:
+        if cimeanText.find(",") > 0:
             cimeanText = self.convertDecimalSeparator(cimeanText)
         ciMean = float(cimeanText)
-        ciThreshold = ciMean - float(ciSTDScale)*ciSTD        
-        arcpy.AddMessage("using ci threshold "+str(ciThreshold))
+        ciThreshold = ciMean - float(ciSTDScale) * ciSTD
+        arcpy.AddMessage("using ci threshold " + str(ciThreshold))
         ciClassRas1 = tempWS + "/" + "ciC"
         interimDataList.append(ciClassRas1)
-        self.selectRaster(ciRas,ciClassRas1,ciThreshold,"<=")
+        self.selectRaster(ciRas, ciClassRas1, ciThreshold, "<=")
         arcpy.AddMessage("CI selection done")
-                
+
         # select TPI based on the threshold
         tpiSTDResult = arcpy.GetRasterProperties_management(tpiRas, "STD")
         tpistdText = tpiSTDResult.getOutput(0)
-        if tpistdText.find(',') > 0:
-            tpistdText = self.convertDecimalSeparator(tpistdText) 
+        if tpistdText.find(",") > 0:
+            tpistdText = self.convertDecimalSeparator(tpistdText)
         tpiSTD = float(tpistdText)
         tpiMEANResult = arcpy.GetRasterProperties_management(tpiRas, "MEAN")
         tpimeanText = tpiMEANResult.getOutput(0)
-        if tpimeanText.find(',') > 0:
+        if tpimeanText.find(",") > 0:
             tpimeanText = self.convertDecimalSeparator(tpimeanText)
         tpiMean = float(tpimeanText)
-        tpiThreshold = tpiMean - float(tpiSTDScale)*tpiSTD        
-        arcpy.AddMessage("using tpi threshold "+str(tpiThreshold))
+        tpiThreshold = tpiMean - float(tpiSTDScale) * tpiSTD
+        arcpy.AddMessage("using tpi threshold " + str(tpiThreshold))
         tpiClassRas1 = tempWS + "/" + "tpiC"
         interimDataList.append(tpiClassRas1)
-        self.selectRaster(tpiRas,tpiClassRas1,tpiThreshold,"<=")
+        self.selectRaster(tpiRas, tpiClassRas1, tpiThreshold, "<=")
         arcpy.AddMessage("TPI selection done")
 
         # mosaic ciC and tpiC
         mosaicRas = "em_ciC_tpiC"
         interimDataList.append(mosaicRas)
-        inputRasters = [ciClassRas1,tpiClassRas1]  
-        arcpy.MosaicToNewRaster_management(inputRasters,tempWS, mosaicRas, tpiClassRas1, "8_BIT_UNSIGNED", cellsize, "1", "MEAN","FIRST")
+        inputRasters = [ciClassRas1, tpiClassRas1]
+        arcpy.MosaicToNewRaster_management(
+            inputRasters,
+            tempWS,
+            mosaicRas,
+            tpiClassRas1,
+            "8_BIT_UNSIGNED",
+            cellsize,
+            "1",
+            "MEAN",
+            "FIRST",
+        )
         arcpy.AddMessage("mosaic done")
-        
+
         # convert raster to polygon
         mosaicRas = tempWS + "/" + "em_ciC_tpiC"
         ci_tpiPoly = tempWS + "/" + "ci_tpiC_poly"
@@ -1308,11 +1548,13 @@ class helpers(object):
 
         # add the "AREA_GEO" field to the polygons
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(ci_tpiPoly,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(
+            ci_tpiPoly, "AREA_GEODESIC", "", areaUnit1
+        )
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThreshold)
-        
+
         # further selection based on the input area threshold
         ci_tpiPoly_selected = tempWS + "/" + "ci_tpiC_poly_selected"
         interimDataList.append(ci_tpiPoly_selected)
@@ -1324,18 +1566,22 @@ class helpers(object):
         ci_tpiPoly_selected1 = tempWS + "/" + "ci_tpiC_poly_selected1"
         interimDataList.append(ci_tpiPoly_selected1)
         areaThreshold = areaThreshold / converter
-        size = str(areaThreshold) + ' ' + areaUnit            
-        arcpy.EliminatePolygonPart_management(ci_tpiPoly_selected, ci_tpiPoly_selected1, "AREA", size, "", "CONTAINED_ONLY")
+        size = str(areaThreshold) + " " + areaUnit
+        arcpy.EliminatePolygonPart_management(
+            ci_tpiPoly_selected,
+            ci_tpiPoly_selected1,
+            "AREA",
+            size,
+            "",
+            "CONTAINED_ONLY",
+        )
         arcpy.AddMessage("elimination holes done")
 
         # copy featureclass
-        arcpy.Copy_management(ci_tpiPoly_selected1,outFeat)
+        arcpy.Copy_management(ci_tpiPoly_selected1, outFeat)
 
         # delete intermediate results
-        self.deleteDataItems(interimDataList)  
+        self.deleteDataItems(interimDataList)
         self.deleteFields(outFeat)
 
         arcpy.AddMessage("TPI CI Low tool is done")
-                    
-                            
-                            

--- a/Tools/ClassificationFeature.pyt
+++ b/Tools/ClassificationFeature.pyt
@@ -7,11 +7,11 @@
 
 import arcpy
 from arcpy import env
-from arcpy.sa import *
-import numpy as np
+
 arcpy.CheckOutExtension("Spatial")
 
-class Toolbox(object):
+
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -20,11 +20,14 @@ class Toolbox(object):
 
         # List of tool classes associated with this toolbox
         # There are two tools. One tool is used to classify Bathymetric High features. The other is used to classify Bathymetric Low features.
-        self.tools = [Classify_Bathymetric_High_Features_Tool,Classify_Bathymetric_Low_Features_Tool]
+        self.tools = [
+            Classify_Bathymetric_High_Features_Tool,
+            Classify_Bathymetric_Low_Features_Tool,
+        ]
 
 
 # This tool is used to classify Bathymetric Low features based on their attributes.
-class Classify_Bathymetric_Low_Features_Tool(object):
+class Classify_Bathymetric_Low_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Classify Bathymetric Low Features Tool"
@@ -40,7 +43,8 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -48,16 +52,18 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
-        
+
         # 3rd parameter
         param2 = arcpy.Parameter(
             displayName="Length_to_Width Ratio Threshold",
             name="lwRatioT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param2.value = 8.0
 
         # 4th parameter
@@ -66,7 +72,8 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="headDepthT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param3.value = 4000.0
 
         # 5th parameter
@@ -75,7 +82,8 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="meanSegmentSlopeT1",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 7.0
 
         # 6th parameter
@@ -84,7 +92,8 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="hfdepthRangeT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 600.0
 
         # 7th parameter
@@ -93,7 +102,8 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="meanSegmentSlopeT2",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 2.0
 
         # 8th parameter
@@ -102,9 +112,10 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             name="circularityT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param7.value = 0.5
-        
+
         parameters = [param0, param1, param2, param3, param4, param5, param6, param7]
         return parameters
 
@@ -116,7 +127,6 @@ class Classify_Bathymetric_Low_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -127,82 +137,117 @@ class Classify_Bathymetric_Low_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         lwRatioT = float(parameters[2].valueAsText)
         headDepthT = float(parameters[3].valueAsText)
         meanSegmentSlopeT1 = float(parameters[4].valueAsText)
-        hfdepthRangeT = float(parameters[5].valueAsText)        
+        hfdepthRangeT = float(parameters[5].valueAsText)
         meanSegmentSlopeT2 = float(parameters[6].valueAsText)
         circularityT = float(parameters[7].valueAsText)
 
         # make sure meanSegmentSlopeT2 is smaller than meanSegmentSlopeT1
         if meanSegmentSlopeT2 > meanSegmentSlopeT1:
-            messages.addErrorMessage('Mean Segment Slope Threshold Small must be smaller than Mean Segment Slope Threshold Large!')
+            messages.addErrorMessage(
+                "Mean Segment Slope Threshold Small must be smaller than Mean Segment Slope Threshold Large!"
+            )
             raise arcpy.ExecuteError
-        
-        # enable helper 
+
+        # enable helper
         helper = helpers()
-        inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)        
+        inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
 
         # if the input feature class is selected from a drop-down list, the inFeatClass does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
-                        
-       # check that the input feature class is in a correct format
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
+
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the input feature class is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
-        
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
         # make sure all the required attributes exist in the input featureclass
-        attributeList = ['featID','LengthWidthRatio','head_foot_depthRange','mean_width','profileSymmetry',
-                         'profile_bottom_SlopeClass','profile_side_SlopeClass','headDepth',
-                         'mean_segment_slope','mean_width_thickness_ratio','mean_thickness',
-                         'width_distance_slope','width_distance_correlation','thick_distance_slope',
-                         'thick_distance_correlation','Circularity']
+        attributeList = [
+            "featID",
+            "LengthWidthRatio",
+            "head_foot_depthRange",
+            "mean_width",
+            "profileSymmetry",
+            "profile_bottom_SlopeClass",
+            "profile_side_SlopeClass",
+            "headDepth",
+            "mean_segment_slope",
+            "mean_width_thickness_ratio",
+            "mean_thickness",
+            "width_distance_slope",
+            "width_distance_correlation",
+            "thick_distance_slope",
+            "thick_distance_correlation",
+            "Circularity",
+        ]
 
-        attributeList = ['featID','LengthWidthRatio','head_foot_depthRange','mean_width','profileSymmetry',
-                         'profile_bottom_SlopeClass','profile_side_SlopeClass','headDepth',
-                         'mean_segment_slope','Circularity']
+        attributeList = [
+            "featID",
+            "LengthWidthRatio",
+            "head_foot_depthRange",
+            "mean_width",
+            "profileSymmetry",
+            "profile_bottom_SlopeClass",
+            "profile_side_SlopeClass",
+            "headDepth",
+            "mean_segment_slope",
+            "Circularity",
+        ]
         for attribute in attributeList:
             if attribute not in field_names:
-                messages.addErrorMessage('The input featureclass does not have ' + attribute + ' attribute. You have to calculate the attribute using the Attributes Tool!')
+                messages.addErrorMessage(
+                    "The input featureclass does not have "
+                    + attribute
+                    + " attribute. You have to calculate the attribute using the Attributes Tool!"
+                )
                 raise arcpy.ExecuteError
 
-        # check the 'Morphological_Feature' field exists    
+        # check the 'Morphological_Feature' field exists
         field = "Morphology_feature"
         fieldType = "TEXT"
         fieldLength = 200
         if field in field_names:
             arcpy.AddMessage(field + " exists and will be recalculated.")
-        else:            
-            arcpy.AddField_management(inFeatClass,field,fieldType,field_length=fieldLength)
-        
+        else:
+            arcpy.AddField_management(
+                inFeatClass, field, fieldType, field_length=fieldLength
+            )
+
         # loop through each feature
         cursor = arcpy.UpdateCursor(inFeatClass)
-       
+
         for row in cursor:
             # get attributes values
             featID = row.getValue("featID")
@@ -211,11 +256,11 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             hfdepthRange = float(row.getValue("head_foot_depthRange"))
             meanWidth = float(row.getValue("mean_width"))
             profileSymmetry = row.getValue("profileSymmetry")
-            profileSymmetryL = profileSymmetry.split(',')
+            profileSymmetryL = profileSymmetry.split(",")
             profileBottomClass = row.getValue("profile_bottom_SlopeClass")
-            profileBottomClassL = profileBottomClass.split(',')
+            profileBottomClassL = profileBottomClass.split(",")
             profileSideClass = row.getValue("profile_side_SlopeClass")
-            profileSideClassL = profileSideClass.split(',')
+            profileSideClassL = profileSideClass.split(",")
             headDepth = float(row.getValue("headDepth"))
             meanSegmentSlope = float(row.getValue("mean_segment_slope"))
             circularity = float(row.getValue("Circularity"))
@@ -226,12 +271,12 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             while j < len(profileBottomClassL):
                 bottomSlope = profileBottomClassL[j]
                 sideSlope = profileSideClassL[j]
-                if bottomSlope == 'no bottom': # triangle profile
+                if bottomSlope == "no bottom":  # triangle profile
                     slopeL.append(sideSlope)
                 else:
                     slopeL.append(bottomSlope)
                 j += 1
-            arcpy.AddMessage('slopeL: ' + str(slopeL))            
+            arcpy.AddMessage("slopeL: " + str(slopeL))
             # bottom slope class count
             flatSlopeCount = slopeL.count("flat")
             gentleSlopeCount = slopeL.count("gentle")
@@ -242,46 +287,59 @@ class Classify_Bathymetric_Low_Features_Tool(object):
             sGentleCount = profileSideClassL.count("gentle")
             sModerateCount = profileSideClassL.count("moderate")
             sSteepCount = profileSideClassL.count("steep")
-            
+
             # profile symmetry class count
-            SymmCount = profileSymmetryL.count('Symmetric')
-            AsymmCount = profileSymmetryL.count('Asymmetric')          
+            SymmCount = profileSymmetryL.count("Symmetric")
+            AsymmCount = profileSymmetryL.count("Asymmetric")
 
             # classification of Bathymetric Low features starts here
             # The classification rules are based on the morphological classification scheme. Please see the metadata of the tool for detailed description of the rules.
-            feature = 'unclassified'
+            feature = "unclassified"
             if lwRatio >= lwRatioT:
                 if abs(headDepth) >= headDepthT:
-                    if (AsymmCount >= SymmCount) and (steepSlopeCount + moderateSlopeCount >= flatSlopeCount + gentleSlopeCount):
-                        feature = 'Trench'
+                    if (AsymmCount >= SymmCount) and (
+                        steepSlopeCount + moderateSlopeCount
+                        >= flatSlopeCount + gentleSlopeCount
+                    ):
+                        feature = "Trench"
                     else:
-                        feature = 'Trough'
+                        feature = "Trough"
                 else:
-                    if (meanSegmentSlope > meanSegmentSlopeT1 ) and (sSteepCount + sModerateCount >= sFlatCount + sGentleCount):                
-                        feature = 'Gully'               
-                    else: 
-                        if (hfdepthRange >= hfdepthRangeT) and (meanSegmentSlope >= meanSegmentSlopeT2):
-                            feature = 'Canyon'
+                    if (meanSegmentSlope > meanSegmentSlopeT1) and (
+                        sSteepCount + sModerateCount >= sFlatCount + sGentleCount
+                    ):
+                        feature = "Gully"
+                    else:
+                        if (hfdepthRange >= hfdepthRangeT) and (
+                            meanSegmentSlope >= meanSegmentSlopeT2
+                        ):
+                            feature = "Canyon"
                         else:
-                            feature = 'Valley/Channel' 
-            else:        
+                            feature = "Valley/Channel"
+            else:
                 sCount = sSteepCount + sModerateCount + sGentleCount + sFlatCount
-                if (sCount == 0):
-                    feature = 'Depression'
-                elif (circularity >= circularityT) and (sSteepCount >= sModerateCount) and (sSteepCount >= sGentleCount) and (sSteepCount >= sFlatCount):
-                    feature = 'Hole'
+                if sCount == 0:
+                    feature = "Depression"
+                elif (
+                    (circularity >= circularityT)
+                    and (sSteepCount >= sModerateCount)
+                    and (sSteepCount >= sGentleCount)
+                    and (sSteepCount >= sFlatCount)
+                ):
+                    feature = "Hole"
                 else:
-                    feature = 'Depression'
+                    feature = "Depression"
 
-            row.setValue(field,feature)
+            row.setValue(field, feature)
             cursor.updateRow(row)
             arcpy.AddMessage(feature)
-        del cursor,row
+        del cursor, row
 
         return
 
+
 # This tool is used to classify Bathymetric High features based on their attributes
-class Classify_Bathymetric_High_Features_Tool(object):
+class Classify_Bathymetric_High_Features_Tool:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Classify Bathymetric High Features Tool"
@@ -297,7 +355,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="inFeatClass",
             datatype="GPFeatureLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -305,16 +364,18 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="outFeatClass",
             datatype="DEFeatureClass",
             parameterType="Derived",
-            direction="Output")
+            direction="Output",
+        )
         param1.parameterDependencies = [param0.name]
-        
+
         # 3rd parameter
         param2 = arcpy.Parameter(
             displayName="Ridge Length_to_Width Ratio Threshold",
             name="ridge_lwRatioT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param2.value = 5.0
 
         # 4th parameter
@@ -323,7 +384,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="bank_minDepthT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param3.value = 200.0
 
         # 5th parameter
@@ -332,7 +394,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="bank_areaT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param4.value = 1.0
 
         # 6th parameter
@@ -341,7 +404,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="plateau_areaT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param5.value = 100.0
 
         # 7th parameter
@@ -350,7 +414,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="hummock_depthRangeT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param6.value = 10.0
 
         # 8th parameter
@@ -359,7 +424,8 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="hummock_areaT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
+            direction="Input",
+        )
         param7.value = 1000.0
 
         # 9th parameter
@@ -368,10 +434,21 @@ class Classify_Bathymetric_High_Features_Tool(object):
             name="cone_circularityT",
             datatype="GPDouble",
             parameterType="Optional",
-            direction="Input")
-        param8.value = 0.75   
-        
-        parameters = [param0, param1, param2, param3, param4, param5, param6, param7, param8]
+            direction="Input",
+        )
+        param8.value = 0.75
+
+        parameters = [
+            param0,
+            param1,
+            param2,
+            param3,
+            param4,
+            param5,
+            param6,
+            param7,
+            param8,
+        ]
         return parameters
 
     def isLicensed(self):
@@ -382,7 +459,6 @@ class Classify_Bathymetric_High_Features_Tool(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -393,7 +469,7 @@ class Classify_Bathymetric_High_Features_Tool(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         inFeatClass = parameters[0].valueAsText
         outFeatClass = parameters[1].valueAsText
         ridge_lwRatioT = float(parameters[2].valueAsText)
@@ -401,60 +477,77 @@ class Classify_Bathymetric_High_Features_Tool(object):
         bank_areaT = float(parameters[4].valueAsText)
         plateau_areaT = float(parameters[5].valueAsText)
         hummock_depthRangeT = float(parameters[6].valueAsText)
-        hummock_areaT = float(parameters[7].valueAsText)        
+        hummock_areaT = float(parameters[7].valueAsText)
         cone_circularityT = float(parameters[8].valueAsText)
-        
+
         # enable helper functions
         helper = helpers()
-        inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)        
+        inFeatClass = helper.convert_backslach_forwardslach(inFeatClass)
         # if the input feature class is selected from a drop-down list, the inFeatClass does not contain the full path
         # In this case, the full path needs to be obtained from the map layer
         if inFeatClass.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isFeatureLayer:
                     if inFeatClass == lyr.name:
-                        inFeatClass = helper.convert_backslach_forwardslach(lyr.dataSource)
-       # check that the input feature class is in a correct format
+                        inFeatClass = helper.convert_backslach_forwardslach(
+                            lyr.dataSource
+                        )
+        # check that the input feature class is in a correct format
         vecDesc = arcpy.Describe(inFeatClass)
-        vecType = vecDesc.dataType        
-        if (vecType != 'FeatureClass') or (inFeatClass.rfind(".gdb") == -1):
-            messages.addErrorMessage("The input featureclass must be a feature class in a File GeoDatabase!")
+        vecType = vecDesc.dataType
+        if (vecType != "FeatureClass") or (inFeatClass.rfind(".gdb") == -1):
+            messages.addErrorMessage(
+                "The input featureclass must be a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-
 
         # check that the input feature class is in a projected coordinate system
         spatialReference = vecDesc.spatialReference
         if spatialReference.type == "Geographic":
-            messages.addErrorMessage("Coordinate system of input featureclass is Geographic. A projected coordinate system is required!")
+            messages.addErrorMessage(
+                "Coordinate system of input featureclass is Geographic. A projected coordinate system is required!"
+            )
             raise arcpy.ExecuteError
-        
-        workspaceName = inFeatClass[0:inFeatClass.rfind("/")] 
-        env.workspace=workspaceName
+
+        workspaceName = inFeatClass[0 : inFeatClass.rfind("/")]
+        env.workspace = workspaceName
         env.overwriteOutput = True
 
-        
         fields = arcpy.ListFields(inFeatClass)
         field_names = [f.name for f in fields]
         # make sure all the required attributes exist in the input featureclass
-        attributeList = ['featID','LengthWidthRatio','depthRange','profileShape',
-                         'profile_top_SlopeClass','profile_side_SlopeClass','minDepth',
-                         'mean_width','Circularity']
+        attributeList = [
+            "featID",
+            "LengthWidthRatio",
+            "depthRange",
+            "profileShape",
+            "profile_top_SlopeClass",
+            "profile_side_SlopeClass",
+            "minDepth",
+            "mean_width",
+            "Circularity",
+        ]
         for attribute in attributeList:
             if attribute not in field_names:
-                messages.addErrorMessage('The input featureclass does not have ' + attribute + ' attribute. You have to calculate the attribute using the Attributes Tool!')
+                messages.addErrorMessage(
+                    "The input featureclass does not have "
+                    + attribute
+                    + " attribute. You have to calculate the attribute using the Attributes Tool!"
+                )
                 raise arcpy.ExecuteError
-        # check the 'Morphological_Feature' field exists    
+        # check the 'Morphological_Feature' field exists
         field = "Morphology_feature"
         fieldType = "TEXT"
         fieldLength = 200
         if field in field_names:
             arcpy.AddMessage(field + " exists and will be recalculated.")
-        else:            
-            arcpy.AddField_management(inFeatClass,field,fieldType,field_length=fieldLength)
-        
-        
+        else:
+            arcpy.AddField_management(
+                inFeatClass, field, fieldType, field_length=fieldLength
+            )
+
         # loop through each feature
         cursor = arcpy.UpdateCursor(inFeatClass)
         i = 1
@@ -465,77 +558,101 @@ class Classify_Bathymetric_High_Features_Tool(object):
             lwRatio = float(row.getValue("LengthWidthRatio"))
             depthRange = float(row.getValue("depthRange"))
             profileShape = row.getValue("profileShape")
-            profileShapeL = profileShape.split(',')
+            profileShapeL = profileShape.split(",")
             profileTopClass = row.getValue("profile_top_SlopeClass")
-            profileTopClassL = profileTopClass.split(',')
+            profileTopClassL = profileTopClass.split(",")
             profileSideClass = row.getValue("profile_side_SlopeClass")
-            profileSideClassL = profileSideClass.split(',')
-            minDepth = float(row.getValue("minDepth")) 
+            profileSideClassL = profileSideClass.split(",")
+            minDepth = float(row.getValue("minDepth"))
             meanWidth = float(row.getValue("mean_width"))
             area = float(row.getValue("Shape_Area"))
             circularity = float(row.getValue("Circularity"))
             # get profile shape class count
-            RegularCount = profileShapeL.count('Regular')
-            IrregularCount = profileShapeL.count('Irregular')
-            TriangleCount = profileShapeL.count('Triangle')
-            FlatCount = profileShapeL.count('Flat')
-            
+            RegularCount = profileShapeL.count("Regular")
+            IrregularCount = profileShapeL.count("Irregular")
+            TriangleCount = profileShapeL.count("Triangle")
+            FlatCount = profileShapeL.count("Flat")
+
             # if profile shape is a triangle, add its profile side slope class
             triangle_sideSlopeL = []
             k = 0
             while k < len(profileShapeL):
                 pShape = profileShapeL[k]
                 sideSlope = profileSideClassL[k]
-                if pShape == 'Triangle':
+                if pShape == "Triangle":
                     triangle_sideSlopeL.append(sideSlope)
                 k += 1
 
             # triangle side slope count
             moderateSlopeCountTriangle = triangle_sideSlopeL.count("moderate")
             steepSlopeCountTriangle = triangle_sideSlopeL.count("steep")
-            
+
             # the top slope list combines profile's top slope and side slope (only when the profile is triangle)
             slopeL = []
             j = 0
             while j < len(profileTopClassL):
                 topSlope = profileTopClassL[j]
                 sideSlope = profileSideClassL[j]
-                if topSlope == 'no top': #triangle profile
+                if topSlope == "no top":  # triangle profile
                     slopeL.append(sideSlope)
                 else:
                     slopeL.append(topSlope)
                 j += 1
 
-            # top slope class count            
+            # top slope class count
             flatSlopeCount = slopeL.count("flat")
             gentleSlopeCount = slopeL.count("gentle")
             moderateSlopeCount = slopeL.count("moderate")
             steepSlopeCount = slopeL.count("steep")
 
-            # side slope class count            
+            # side slope class count
             flatSlopeCountSide = profileSideClassL.count("flat")
             gentleSlopeCountSide = profileSideClassL.count("gentle")
             moderateSlopeCountSide = profileSideClassL.count("moderate")
-            steepSlopeCountSide = profileSideClassL.count("steep")            
+            steepSlopeCountSide = profileSideClassL.count("steep")
 
             # classification of Bathymetric High features starts here
             # The classification rules are based on the morphological classification scheme. Please see the metadata of the tool for detailed description of the rules.
             feature = "unclassified"
-            
+
             if lwRatio >= ridge_lwRatioT:
                 feature = "Ridge"
             elif depthRange >= 1000:
                 feature = "Seamount"
             elif depthRange >= meanWidth:
                 feature = "Pinnacle"
-            elif (TriangleCount >= RegularCount) and (TriangleCount >= IrregularCount) and (TriangleCount >= FlatCount) and (moderateSlopeCountTriangle + steepSlopeCountTriangle >= 1) and (circularity >= cone_circularityT):
+            elif (
+                (TriangleCount >= RegularCount)
+                and (TriangleCount >= IrregularCount)
+                and (TriangleCount >= FlatCount)
+                and (moderateSlopeCountTriangle + steepSlopeCountTriangle >= 1)
+                and (circularity >= cone_circularityT)
+            ):
                 feature = "Cone"
-            elif (flatSlopeCount >=  gentleSlopeCount + moderateSlopeCount + steepSlopeCount) and (abs(minDepth) <= bank_minDepthT) and (area > bank_areaT * 1000000):
+            elif (
+                (
+                    flatSlopeCount
+                    >= gentleSlopeCount + moderateSlopeCount + steepSlopeCount
+                )
+                and (abs(minDepth) <= bank_minDepthT)
+                and (area > bank_areaT * 1000000)
+            ):
                 feature = "Bank"
-            elif (flatSlopeCount >=  gentleSlopeCount + moderateSlopeCount + steepSlopeCount) and (moderateSlopeCountSide + steepSlopeCountSide >= 1) and (area > plateau_areaT * 1000000):
-                feature = "Plateau" 
+            elif (
+                (
+                    flatSlopeCount
+                    >= gentleSlopeCount + moderateSlopeCount + steepSlopeCount
+                )
+                and (moderateSlopeCountSide + steepSlopeCountSide >= 1)
+                and (area > plateau_areaT * 1000000)
+            ):
+                feature = "Plateau"
             elif depthRange >= 500:
-                if (RegularCount >= IrregularCount) and (RegularCount >= TriangleCount) and (RegularCount >= FlatCount):
+                if (
+                    (RegularCount >= IrregularCount)
+                    and (RegularCount >= TriangleCount)
+                    and (RegularCount >= FlatCount)
+                ):
                     feature = "Knoll"
                 else:
                     feature = "Hill"
@@ -543,27 +660,28 @@ class Classify_Bathymetric_High_Features_Tool(object):
                 feature = "Hummock"
             else:
                 feature = "Mound"
-            row.setValue(field,feature)
+            row.setValue(field, feature)
             cursor.updateRow(row)
             arcpy.AddMessage(feature)
             i += 1
-        del cursor,row
+        del cursor, row
 
         return
 
-# define helper functions here
-class helpers(object):
-    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
-        # inText: input path
-        
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
 
-        inText = inText.replace('\\','/')
+# define helper functions here
+class helpers:
+    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
+    def convert_backslach_forwardslach(self, inText):
+        # inText: input path
+
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
+
+        inText = inText.replace("\\", "/")
         return inText

--- a/Tools/Surface.pyt
+++ b/Tools/Surface.pyt
@@ -5,17 +5,12 @@
 #### Python version: 3+
 #### ArcGIS Pro: 2.6.4 and above
 
+
 import arcpy
-from arcpy import env
-from arcpy.sa import *
-import os
-import math
-import numpy as np
-import warnings
-from datetime import datetime
+from arcpy.sa import MajorityFilter, Reclassify, RemapRange, Slope
 
 
-class Toolbox(object):
+class Toolbox:
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
@@ -24,14 +19,17 @@ class Toolbox(object):
 
         # List of tool classes associated with this toolbox
         # There are two tools. One tool is used to generate three-class morphological surface from a bathymetry grid. The other is used to generate three-class morphological surface from a slope grid.
-        self.tools = [SurfaceToolBathy,SurfaceToolSlope]
+        self.tools = [SurfaceToolBathy, SurfaceToolSlope]
+
 
 # This tool is used to generate three-class morphological surface from a bathymetry grid.
-class SurfaceToolBathy(object):
+class SurfaceToolBathy:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Morphological Surface Tool Bathymetry"
-        self.description = "Generate three morphological surface classes from bathymetry"
+        self.description = (
+            "Generate three morphological surface classes from bathymetry"
+        )
         self.canRunInBackground = False
 
     def getParameterInfo(self):
@@ -43,7 +41,8 @@ class SurfaceToolBathy(object):
             name="bathyRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -51,7 +50,8 @@ class SurfaceToolBathy(object):
             name="slopeRas",
             datatype="DERasterDataset",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -59,7 +59,8 @@ class SurfaceToolBathy(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # fourth parameter
         param3 = arcpy.Parameter(
@@ -67,26 +68,29 @@ class SurfaceToolBathy(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")       
-        
+            direction="Input",
+        )
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="Number of times to apply Majority Filter",
             name="nuMF",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
-        param4.value = 3        
-        
+            direction="Input",
+        )
+        param4.value = 3
+
         # sixth parameter
         param5 = arcpy.Parameter(
             displayName="Temporary Workspace",
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param5.defaultEnvironmentName = "workspace"
-        
+
         parameters = [param0, param1, param2, param3, param4, param5]
         return parameters
 
@@ -98,7 +102,6 @@ class SurfaceToolBathy(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -109,7 +112,7 @@ class SurfaceToolBathy(object):
 
     def execute(self, parameters, messages):
         """The source code of the tool."""
-        
+
         bathyRas = parameters[0].valueAsText
         slopeRas = parameters[1].valueAsText
         outFeat = parameters[2].valueAsText
@@ -127,61 +130,73 @@ class SurfaceToolBathy(object):
         # In this case, the full path needs to be obtained from the map layer
         if bathyRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if bathyRas == lyr.name:
                         bathyRas = helper.convert_backslach_forwardslach(lyr.dataSource)
-        
+
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(bathyRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input bathymetry raster must be a raster dataset in a File GeoDatabase!")
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input bathymetry raster must be a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        
+
         # check that the output slope grid is in a correct format
         if slopeRas.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output slope raster must be nominated as a raster dataset in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output slope raster must be nominated as a raster dataset in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the output featureclass is in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace is in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
-        workspaceName = bathyRas[0:bathyRas.rfind("/")]
+        workspaceName = bathyRas[0 : bathyRas.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        
+        areaUnit = areaThreshold.split(" ")[1]
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-  
+
         # Check out the ArcGIS Spatial Analyst extension license
         arcpy.CheckOutExtension("Spatial")
-        arcpy.env.workspace=workspaceName
+        arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to generate morphological surface classes
-        helper.Surface_Tool_bathy(tempWS,bathyRas,slopeRas,outFeat,areaThresholdValue,areaUnit,nuMF)
+        helper.Surface_Tool_bathy(
+            tempWS, bathyRas, slopeRas, outFeat, areaThresholdValue, areaUnit, nuMF
+        )
         return
 
+
 # This tool is used to generate three-class morphological surface from a slope grid.
-class SurfaceToolSlope(object):
+class SurfaceToolSlope:
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
         self.label = "Morphological Surface Tool Slope"
-        self.description = "Generate three morphological surface classes from slope grid"
+        self.description = (
+            "Generate three morphological surface classes from slope grid"
+        )
         self.canRunInBackground = False
 
     def getParameterInfo(self):
         """Define parameter definitions"""
-
 
         # first parameter
         param0 = arcpy.Parameter(
@@ -189,7 +204,8 @@ class SurfaceToolSlope(object):
             name="slopeRas",
             datatype="GPRasterLayer",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
 
         # second parameter
         param1 = arcpy.Parameter(
@@ -197,7 +213,8 @@ class SurfaceToolSlope(object):
             name="outFeat",
             datatype="DEFeatureClass",
             parameterType="Required",
-            direction="Output")
+            direction="Output",
+        )
 
         # third parameter
         param2 = arcpy.Parameter(
@@ -205,28 +222,29 @@ class SurfaceToolSlope(object):
             name="areaThreshold",
             datatype="GPArealUnit",
             parameterType="Required",
-            direction="Input")
-       
-        
+            direction="Input",
+        )
+
         # fourth parameter
         param3 = arcpy.Parameter(
             displayName="Number of times to apply Majority Filter",
             name="nuMF",
             datatype="GPLong",
             parameterType="Required",
-            direction="Input")
+            direction="Input",
+        )
         param3.value = 3
-        
-        
+
         # fifth parameter
         param4 = arcpy.Parameter(
             displayName="Temporary Workspace",
             name="tempWS",
             datatype="DEWorkspace",
             parameterType="required",
-            direction="Input")        
+            direction="Input",
+        )
         param4.defaultEnvironmentName = "workspace"
-        
+
         parameters = [param0, param1, param2, param3, param4]
         return parameters
 
@@ -238,7 +256,6 @@ class SurfaceToolSlope(object):
         """Modify the values and properties of parameters before internal
         validation is performed.  This method is called whenever a parameter
         has been changed."""
-        
 
         return
 
@@ -248,8 +265,8 @@ class SurfaceToolSlope(object):
         return
 
     def execute(self, parameters, messages):
-        """The source code of the tool."""        
-   
+        """The source code of the tool."""
+
         slopeRas = parameters[0].valueAsText
         outFeat = parameters[1].valueAsText
         areaThreshold = parameters[2].valueAsText
@@ -265,68 +282,77 @@ class SurfaceToolSlope(object):
         # In this case, the full path needs to be obtained from the map layer
         if slopeRas.rfind("/") < 0:
             aprx = arcpy.mp.ArcGISProject("CURRENT")
-            m = aprx.activeMap            
+            m = aprx.activeMap
             for lyr in m.listLayers():
                 if lyr.isRasterLayer:
                     if slopeRas == lyr.name:
                         slopeRas = helper.convert_backslach_forwardslach(lyr.dataSource)
-        
 
         # check that the input bathymetry grid is in a correct format
         rasDesc = arcpy.Describe(slopeRas)
         rasFormat = rasDesc.format
-        if rasFormat != 'FGDBR':
-            messages.addErrorMessage("The input slope raster must be a raster dataset in a File GeoDatabase!")
-            raise arcpy.ExecuteError        
+        if rasFormat != "FGDBR":
+            messages.addErrorMessage(
+                "The input slope raster must be a raster dataset in a File GeoDatabase!"
+            )
+            raise arcpy.ExecuteError
 
         # check that the output featureclass is in a correct format
         if outFeat.rfind(".gdb") == -1:
-            messages.addErrorMessage("The output featureclass must be nominated as a feature class in a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The output featureclass must be nominated as a feature class in a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
 
         # check that the temporary workspace is in a correct format
         if tempWS.rfind(".gdb") == -1:
-            messages.addErrorMessage("The temporary workspace must be nominated as a File GeoDatabase!")
+            messages.addErrorMessage(
+                "The temporary workspace must be nominated as a File GeoDatabase!"
+            )
             raise arcpy.ExecuteError
-        workspaceName = slopeRas[0:slopeRas.rfind("/")]
+        workspaceName = slopeRas[0 : slopeRas.rfind("/")]
         areaThresholdValue = areaThreshold.split(" ")[0]
-        areaUnit =  areaThreshold.split(" ")[1]
-        
+        areaUnit = areaThreshold.split(" ")[1]
+
         if areaUnit == "Unknown":
             messages.addErrorMessage("You cann't provide an unknown area unit.")
             raise arcpy.ExecuteError
-  
+
         # Check out the ArcGIS Spatial Analyst extension license
         arcpy.CheckOutExtension("Spatial")
-        arcpy.env.workspace=workspaceName
+        arcpy.env.workspace = workspaceName
         arcpy.env.overwriteOutput = True
         # call the helper function to generate morphological surface classes
-        helper.Surface_Tool_slope(tempWS,slopeRas,outFeat,areaThresholdValue,areaUnit,nuMF)
+        helper.Surface_Tool_slope(
+            tempWS, slopeRas, outFeat, areaThresholdValue, areaUnit, nuMF
+        )
         return
-# helper functions are defined here
-class helpers(object):
-    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
-    def convert_backslach_forwardslach(self,inText):
-        # inText: input path
-        
-        inText = fr"{inText}"
-        if inText.find('\t'):
-            inText = inText.replace('\t', '\\t')
-        elif inText.find('\n'):
-            inText = inText.replace('\n', '\\n')
-        elif inText.find('\r'):
-            inText = inText.replace('\r', '\\r')
 
-        inText = inText.replace('\\','/')
+
+# helper functions are defined here
+class helpers:
+    # This function converts backslach (accepted through the ArcGIS tool) to forwardslach (needed in python script) in a path
+    def convert_backslach_forwardslach(self, inText):
+        # inText: input path
+
+        inText = rf"{inText}"
+        if inText.find("\t"):
+            inText = inText.replace("\t", "\\t")
+        elif inText.find("\n"):
+            inText = inText.replace("\n", "\\n")
+        elif inText.find("\r"):
+            inText = inText.replace("\r", "\\r")
+
+        inText = inText.replace("\\", "/")
         return inText
 
     # This function deletes all intermediate data items
-    def deleteDataItems(self,inDataList):
+    def deleteDataItems(self, inDataList):
         # inDataList: a list of data items to be deleted
-        
+
         if len(inDataList) == 0:
             arcpy.AddMessage("no data item in the list")
-            
+
         else:
             for item in inDataList:
                 arcpy.AddMessage("Deleting " + item)
@@ -334,9 +360,9 @@ class helpers(object):
         return
 
     # This function calculates a converter value for the input area unit. The base unit is "SquareKilometers".
-    def areaUnitConverter(self,inAreaUnit):
+    def areaUnitConverter(self, inAreaUnit):
         # inAreaUnit: input Area Unit
-        
+
         if inAreaUnit == "Acres":
             converter = 0.00404686
         elif inAreaUnit == "Ares":
@@ -360,12 +386,14 @@ class helpers(object):
         elif inAreaUnit == "SquareMillimeters":
             converter = 0.000000000001
         elif inAreaUnit == "SquareYards":
-            converter = 0.00000083613       
+            converter = 0.00000083613
 
         return converter
 
     # This function generate three-class morphological surface from a bathymetry grid
-    def Surface_Tool_bathy(self,tempWS,bathyRas,slopeRas,outFeat,areaThresholdValue,areaUnit,nuMF):
+    def Surface_Tool_bathy(
+        self, tempWS, bathyRas, slopeRas, outFeat, areaThresholdValue, areaUnit, nuMF
+    ):
         # tempWS: temporary workspace to store temporary data
         # bathyRas: input bathymetry grid
         # slopeRas: output slope grid
@@ -373,24 +401,24 @@ class helpers(object):
         # areaThresholdValue: input area threshold value
         # areaUnit: input area unit of the areaThreshold
         # nuMF: number of times applying Majority Filter
-        
+
         arcpy.AddMessage("running generate surface from bathmetry tool ...")
         interimDataList = []
         # calculate slope raster
-        slopeRasName = slopeRas[slopeRas.rfind("/")+1:]
-        slopeRas1 = tempWS + "/" + slopeRasName        
+        slopeRasName = slopeRas[slopeRas.rfind("/") + 1 :]
+        slopeRas1 = tempWS + "/" + slopeRasName
         # If the slope raster already exists in a backup directory, just copied the raster to the workspace.
         # The intension is to calculate slope raster only once,
         # as the calculation may takes a long time depending on the size of the bathymetric grid.
         if arcpy.Exists(slopeRas1):
-            arcpy.Copy_management(slopeRas1,slopeRas)
-            arcpy.AddMessage(slopeRas+' exists and will be used')        
+            arcpy.Copy_management(slopeRas1, slopeRas)
+            arcpy.AddMessage(slopeRas + " exists and will be used")
         else:
-            arcpy.AddMessage("calculating slope...")        
+            arcpy.AddMessage("calculating slope...")
             outSlope = Slope(bathyRas)
             outSlope.save(slopeRas)
         # copy the slope raster to a backup directory
-        arcpy.Copy_management(slopeRas,slopeRas1)
+        arcpy.Copy_management(slopeRas, slopeRas1)
 
         # reclassify the slope raster based on the folowing conditions
         arcpy.AddMessage("Reclassifing ...")
@@ -398,8 +426,8 @@ class helpers(object):
         interimDataList.append(rcRas)
         reclassField = "Value"
         # 0-2 degree: Plane; 2-10 degree: Slope; >10 degree: Escarpment
-        remap = RemapRange([[0,2,1],[2,10,2],[10,90,3]])
-        outReclassify = Reclassify(slopeRas,reclassField,remap,"NODATA")
+        remap = RemapRange([[0, 2, 1], [2, 10, 2], [10, 90, 3]])
+        outReclassify = Reclassify(slopeRas, reclassField, remap, "NODATA")
         outReclassify.save(rcRas)
 
         # apply majority filter a number of times to smooth th reclassified grid
@@ -412,7 +440,7 @@ class helpers(object):
         i = 1
         while i < int(nuMF):
             outMF = MajorityFilter(MFRasName, "EIGHT", "HALF")
-            MFRasName = tempWS + "/MFRas" + str(i+1)
+            MFRasName = tempWS + "/MFRas" + str(i + 1)
             interimDataList.append(MFRasName)
             arcpy.AddMessage(MFRasName)
             outMF.save(MFRasName)
@@ -422,119 +450,137 @@ class helpers(object):
         arcpy.AddMessage("Converting raster to polygon ...")
         outFeat1 = tempWS + "/outFeat_temp1"
         interimDataList.append(outFeat1)
-        arcpy.RasterToPolygon_conversion(MFRasName,outFeat1,"NO_SIMPLIFY","VALUE")
-        # add and calculate an Area field 
+        arcpy.RasterToPolygon_conversion(MFRasName, outFeat1, "NO_SIMPLIFY", "VALUE")
+        # add and calculate an Area field
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(outFeat1,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(outFeat1, "AREA_GEODESIC", "", areaUnit1)
         result = arcpy.GetCount_management(outFeat1)
         count = int(result[0])
-        
-        # eliminate small polygons 
-   
+
+        # eliminate small polygons
+
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThresholdValue)
         where_clause = '"AREA_GEO" < ' + str(areaThreshold)
-        
+
         # eliminate based on the area attribute
         eliminatedFeat = tempWS + "/eliminatedFeat" + str(i)
         interimDataList.append(eliminatedFeat)
-        
-        layerName = "lyr1"      
+
+        layerName = "lyr1"
         arcpy.MakeFeatureLayer_management(outFeat1, layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
         result = arcpy.GetCount_management(layerName)
-        if int(result[0]) > 0:        
+        if int(result[0]) > 0:
             eliminatedFeat = tempWS + "/eliminatedFeat1"
             interimDataList.append(eliminatedFeat)
-            arcpy.Eliminate_management(layerName,eliminatedFeat,"AREA")
+            arcpy.Eliminate_management(layerName, eliminatedFeat, "AREA")
             result = arcpy.GetCount_management(eliminatedFeat)
             countNew = int(result[0])
-            if countNew == count: # nothing to eliminate
-                arcpy.Copy_management(eliminatedFeat,outFeat)
+            if countNew == count:  # nothing to eliminate
+                arcpy.Copy_management(eliminatedFeat, outFeat)
                 arcpy.AddMessage("Eliminate done. Final features generated.")
             else:
-                count = countNew                
+                count = countNew
                 i = 2
-                while i < 1000: # continue loop until nothing to eliminate
-                    layerName = "lyr" + str(i)      
+                while i < 1000:  # continue loop until nothing to eliminate
+                    layerName = "lyr" + str(i)
                     arcpy.MakeFeatureLayer_management(eliminatedFeat, layerName)
-                    arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
+                    arcpy.SelectLayerByAttribute_management(
+                        layerName, "NEW_SELECTION", where_clause
+                    )
                     result = arcpy.GetCount_management(layerName)
                     if int(result[0]) > 0:
                         eliminatedFeat = tempWS + "/eliminatedFeat" + str(i)
                         interimDataList.append(eliminatedFeat)
-                        arcpy.Eliminate_management(layerName,eliminatedFeat,"AREA")
+                        arcpy.Eliminate_management(layerName, eliminatedFeat, "AREA")
                         result = arcpy.GetCount_management(eliminatedFeat)
                         countNew = int(result[0])
                         if countNew == count:
-                            arcpy.Copy_management(eliminatedFeat,outFeat)
-                            arcpy.AddMessage("Eliminate done. Final features generated.")
-                            break;
+                            arcpy.Copy_management(eliminatedFeat, outFeat)
+                            arcpy.AddMessage(
+                                "Eliminate done. Final features generated."
+                            )
+                            break
                         else:
                             count = countNew
                             arcpy.AddMessage(str(count))
                             i += 1
                     else:
-                        arcpy.Copy_management(eliminatedFeat,outFeat)
+                        arcpy.Copy_management(eliminatedFeat, outFeat)
                         arcpy.AddMessage("Eliminate done. Final features generated.")
-                        break;
+                        break
         else:
-            arcpy.Copy_management(outFeat1,outFeat)
-            arcpy.AddMessage("Nothing to eliminate. All polygons have area greater than the threshold. Final features generated.")
+            arcpy.Copy_management(outFeat1, outFeat)
+            arcpy.AddMessage(
+                "Nothing to eliminate. All polygons have area greater than the threshold. Final features generated."
+            )
 
         # add and calculate surface field
         fieldName = "surface"
         fieldType = "TEXT"
         fieldLength = 255
-        arcpy.AddField_management(outFeat,fieldName,fieldType,field_length=fieldLength)
-        
+        arcpy.AddField_management(
+            outFeat, fieldName, fieldType, field_length=fieldLength
+        )
+
         where_clause = '"gridcode" = 1'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Plane'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Plane'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
 
         where_clause = '"gridcode" = 2'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Slope'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Slope'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
 
         where_clause = '"gridcode" = 3'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Escarpment'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Escarpment'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
-        
+
         self.deleteDataItems(interimDataList)
-        
-    # This function generate three-class morphological surface from a bathymetry grid    
-    def Surface_Tool_slope(self,tempWS,slopeRas,outFeat,areaThresholdValue,areaUnit,nuMF):
+
+    # This function generate three-class morphological surface from a bathymetry grid
+    def Surface_Tool_slope(
+        self, tempWS, slopeRas, outFeat, areaThresholdValue, areaUnit, nuMF
+    ):
         # tempWS: temporary workspace to store temporary data
         # slopeRas: input slope grid
         # outFeat: output morphological surface
         # areaThresholdValue: input area threshold value
         # areaUnit: input area unit of the areaThreshold
         # nuMF: number of times applying Majority Filter
-                
+
         arcpy.AddMessage("running generate surface from slope tool ...")
         interimDataList = []
- 
+
         # reclassify the slope raster based on the folowing conditions
         arcpy.AddMessage("Reclassifing ...")
         rcRas = tempWS + "/rcRas"
         interimDataList.append(rcRas)
         reclassField = "Value"
         # 0-2 degree: Plane; 2-10 degree: Slope; >10 degree: Escarpment
-        remap = RemapRange([[0,2,1],[2,10,2],[10,90,3]])
-        outReclassify = Reclassify(slopeRas,reclassField,remap,"NODATA")
+        remap = RemapRange([[0, 2, 1], [2, 10, 2], [10, 90, 3]])
+        outReclassify = Reclassify(slopeRas, reclassField, remap, "NODATA")
         outReclassify.save(rcRas)
 
         # apply majority filter a number of times to smooth th reclassified grid
@@ -547,7 +593,7 @@ class helpers(object):
         i = 1
         while i < int(nuMF):
             outMF = MajorityFilter(MFRasName, "EIGHT", "HALF")
-            MFRasName = tempWS + "/MFRas" + str(i+1)
+            MFRasName = tempWS + "/MFRas" + str(i + 1)
             interimDataList.append(MFRasName)
             arcpy.AddMessage(MFRasName)
             outMF.save(MFRasName)
@@ -558,101 +604,111 @@ class helpers(object):
         arcpy.AddMessage("Converting raster to polygon ...")
         outFeat1 = tempWS + "/outFeat_temp1"
         interimDataList.append(outFeat1)
-        arcpy.RasterToPolygon_conversion(MFRasName,outFeat1,"NO_SIMPLIFY","VALUE")
-        # add and calculate an Area field 
+        arcpy.RasterToPolygon_conversion(MFRasName, outFeat1, "NO_SIMPLIFY", "VALUE")
+        # add and calculate an Area field
         areaUnit1 = "SQUARE_KILOMETERS"
-        arcpy.AddGeometryAttributes_management(outFeat1,"AREA_GEODESIC","",areaUnit1)
+        arcpy.AddGeometryAttributes_management(outFeat1, "AREA_GEODESIC", "", areaUnit1)
         result = arcpy.GetCount_management(outFeat1)
         count = int(result[0])
-        
-        # eliminate small polygons 
-   
+
+        # eliminate small polygons
+
         # convert the input area unit to "SQUARE_KILOMETERS"
         converter = self.areaUnitConverter(areaUnit)
         areaThreshold = converter * float(areaThresholdValue)
         where_clause = '"AREA_GEO" < ' + str(areaThreshold)
-        
+
         # eliminate based on the area attribute
         eliminatedFeat = tempWS + "/eliminatedFeat" + str(i)
         interimDataList.append(eliminatedFeat)
-        
-        layerName = "lyr1"      
+
+        layerName = "lyr1"
         arcpy.MakeFeatureLayer_management(outFeat1, layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
         result = arcpy.GetCount_management(layerName)
-        if int(result[0]) > 0:        
+        if int(result[0]) > 0:
             eliminatedFeat = tempWS + "/eliminatedFeat1"
             interimDataList.append(eliminatedFeat)
-            arcpy.Eliminate_management(layerName,eliminatedFeat,"AREA")
+            arcpy.Eliminate_management(layerName, eliminatedFeat, "AREA")
             result = arcpy.GetCount_management(eliminatedFeat)
             countNew = int(result[0])
-            if countNew == count: # nothing to eliminate
-                arcpy.Copy_management(eliminatedFeat,outFeat)
+            if countNew == count:  # nothing to eliminate
+                arcpy.Copy_management(eliminatedFeat, outFeat)
                 arcpy.AddMessage("Eliminate done. Final features generated.")
             else:
-                count = countNew                
+                count = countNew
                 i = 2
-                while i < 1000:   # continue loop until nothing to eliminate
-                    layerName = "lyr" + str(i)      
+                while i < 1000:  # continue loop until nothing to eliminate
+                    layerName = "lyr" + str(i)
                     arcpy.MakeFeatureLayer_management(eliminatedFeat, layerName)
-                    arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
+                    arcpy.SelectLayerByAttribute_management(
+                        layerName, "NEW_SELECTION", where_clause
+                    )
                     result = arcpy.GetCount_management(layerName)
                     if int(result[0]) > 0:
                         eliminatedFeat = tempWS + "/eliminatedFeat" + str(i)
                         interimDataList.append(eliminatedFeat)
-                        arcpy.Eliminate_management(layerName,eliminatedFeat,"AREA")
+                        arcpy.Eliminate_management(layerName, eliminatedFeat, "AREA")
                         result = arcpy.GetCount_management(eliminatedFeat)
                         countNew = int(result[0])
                         if countNew == count:
-                            arcpy.Copy_management(eliminatedFeat,outFeat)
-                            arcpy.AddMessage("Eliminate done. Final features generated.")
-                            break;
+                            arcpy.Copy_management(eliminatedFeat, outFeat)
+                            arcpy.AddMessage(
+                                "Eliminate done. Final features generated."
+                            )
+                            break
                         else:
                             count = countNew
                             arcpy.AddMessage(str(count))
                             i += 1
                     else:
-                        arcpy.Copy_management(eliminatedFeat,outFeat)
+                        arcpy.Copy_management(eliminatedFeat, outFeat)
                         arcpy.AddMessage("Eliminate done. Final features generated.")
-                        break;
+                        break
         else:
-            arcpy.Copy_management(outFeat1,outFeat)
-            arcpy.AddMessage("Nothing to eliminate. All polygons have area greater than the threshold. Final features generated.")
+            arcpy.Copy_management(outFeat1, outFeat)
+            arcpy.AddMessage(
+                "Nothing to eliminate. All polygons have area greater than the threshold. Final features generated."
+            )
 
         # add and calculate surface field
         fieldName = "surface"
         fieldType = "TEXT"
         fieldLength = 255
-        arcpy.AddField_management(outFeat,fieldName,fieldType,field_length=fieldLength)
-        
+        arcpy.AddField_management(
+            outFeat, fieldName, fieldType, field_length=fieldLength
+        )
+
         where_clause = '"gridcode" = 1'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Plane'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Plane'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
 
         where_clause = '"gridcode" = 2'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Slope'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Slope'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
 
         where_clause = '"gridcode" = 3'
         layerName = "tempLyr"
-        arcpy.MakeFeatureLayer_management(outFeat,layerName)
-        arcpy.SelectLayerByAttribute_management(layerName, "NEW_SELECTION", where_clause)
-        expression = "'Escarpment'" 
+        arcpy.MakeFeatureLayer_management(outFeat, layerName)
+        arcpy.SelectLayerByAttribute_management(
+            layerName, "NEW_SELECTION", where_clause
+        )
+        expression = "'Escarpment'"
         arcpy.CalculateField_management(layerName, fieldName, expression, "PYTHON_9.3")
         arcpy.Delete_management(layerName)
 
         self.deleteDataItems(interimDataList)
-        
-                
-        
-
-        
-        

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 90
+target-version = ['py36', 'py37', 'py38']
+include = '\.py[it]?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | versioneer.py
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 90
+line-length = 88
 target-version = ['py36', 'py37', 'py38']
 include = '\.py[it]?$'
 exclude = '''
@@ -20,3 +20,6 @@ exclude = '''
   | versioneer.py
 )
 '''
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Bulk applying python formatting using:

[shed](https://github.com/Zac-HD/shed) which ultimately relies on a few key tools, namely:

[isort](https://github.com/PyCQA/isort)
[black](https://github.com/psf/black)

Executing as follows:

```shell
shed Tools/*.pyt
```

This is largely due to the `.pyt` extension being recognised as a normal Python file.
If running black independently of shed, the `.pyt` extension is catered for in the regular expression specified in the config section for black in the `pyproject.toml` file.

IDE's should be able to integrate with the `pyproject.toml` file when integrating black.